### PR TITLE
feat(hypertable): composite PK on geo_events

### DIFF
--- a/apps/default/cmd/main.go
+++ b/apps/default/cmd/main.go
@@ -225,10 +225,20 @@ func seedDefaultData(ctx context.Context, svc *frame.Service, dek *aconfig.DEK) 
 	propertyEntryRepo := repository.NewPropertyEntryRepository(ctx, dbPool, workMan)
 	addressRepo := repository.NewAddressRepository(ctx, dbPool, workMan)
 	addressBiz := business.NewAddressBusiness(ctx, addressRepo)
-	profileBiz := business.NewProfileBusiness(ctx, cfg, dek, evtsMan, contactBiz, addressBiz, profileRepo, propertyEntryRepo)
+	profileBiz := business.NewProfileBusiness(
+		ctx,
+		cfg,
+		dek,
+		evtsMan,
+		contactBiz,
+		addressBiz,
+		profileRepo,
+		propertyEntryRepo,
+	)
 
 	if err := business.SeedBootstrapContacts(ctx, profileBiz, contactBiz); err != nil {
-		log.WithError(err).Fatal("failed to seed bootstrap contacts — migration incomplete, check DEK env vars")
+		log.WithError(err).
+			Fatal("failed to seed bootstrap contacts — migration incomplete, check DEK env vars")
 	}
 }
 
@@ -241,7 +251,9 @@ func setupConnectServer(ctx context.Context, svc *frame.Service, dek *aconfig.DE
 
 	auth := securityMan.GetAuthorizer(ctx)
 	tenancyAccessChecker := authorizer.NewTenancyAccessChecker(auth, authz.NamespaceTenancyAccess)
-	tenancyAccessInterceptor := connectInterceptors.NewTenancyAccessInterceptor(tenancyAccessChecker)
+	tenancyAccessInterceptor := connectInterceptors.NewTenancyAccessInterceptor(
+		tenancyAccessChecker,
+	)
 
 	// Build procedure map from proto annotations and exclude self-bypass RPCs.
 	sd := profilepb.File_profile_v1_profile_proto.Services().ByName("ProfileService")
@@ -259,7 +271,10 @@ func setupConnectServer(ctx context.Context, svc *frame.Service, dek *aconfig.DE
 	delete(procMap, "/profile.v1.ProfileService/ListRelationships")
 
 	functionChecker := authorizer.NewFunctionChecker(auth, permissions.ForService(sd).Namespace)
-	functionAccessInterceptor := connectInterceptors.NewFunctionAccessInterceptor(functionChecker, procMap)
+	functionAccessInterceptor := connectInterceptors.NewFunctionAccessInterceptor(
+		functionChecker,
+		procMap,
+	)
 
 	// Audit interceptor — sends entries to audit service if configured.
 	profileCfg, _ := svc.Config().(*aconfig.ProfileConfig)
@@ -270,7 +285,9 @@ func setupConnectServer(ctx context.Context, svc *frame.Service, dek *aconfig.DE
 			Audiences: []string{"service_audit"},
 		}, audit.NewConnectClient)
 		if auditErr != nil {
-			util.Log(ctx).WithError(auditErr).Warn("audit client not available — audit entries will only be logged")
+			util.Log(ctx).
+				WithError(auditErr).
+				Warn("audit client not available — audit entries will only be logged")
 			auditInterceptor = audit.NewInterceptor("service_profile", nil)
 		} else {
 			auditInterceptor = audit.NewInterceptor("service_profile", auditCli)
@@ -295,7 +312,10 @@ func setupConnectServer(ctx context.Context, svc *frame.Service, dek *aconfig.DE
 	_, serverHandler := profilev1connect.NewProfileServiceHandler(
 		implementation, connect.WithInterceptors(defaultInterceptorList...))
 
-	publicRestHandler := securityhttp.AuthenticationMiddleware(implementation.NewSecureRouterV1(), authenticator)
+	publicRestHandler := securityhttp.AuthenticationMiddleware(
+		implementation.NewSecureRouterV1(),
+		authenticator,
+	)
 
 	mux := http.NewServeMux()
 	mux.Handle("/", serverHandler)

--- a/apps/default/service/business/profiles.go
+++ b/apps/default/service/business/profiles.go
@@ -27,7 +27,10 @@ var ErrContactNotFound = errors.New("contact not found")
 
 type ProfileBusiness interface {
 	GetByID(ctx context.Context, profileID string) (*profilev1.ProfileObject, error)
-	GetByIDAndPartition(ctx context.Context, profileID, partitionID string) (*profilev1.ProfileObject, error)
+	GetByIDAndPartition(
+		ctx context.Context,
+		profileID, partitionID string,
+	) (*profilev1.ProfileObject, error)
 	GetByContact(ctx context.Context, detail string) (*profilev1.ProfileObject, error)
 
 	SearchProfile(
@@ -35,16 +38,36 @@ type ProfileBusiness interface {
 		request *profilev1.SearchRequest,
 	) (workerpool.JobResultPipe[[]*models.Profile], error)
 
-	CreateProfile(ctx context.Context, request *profilev1.CreateRequest) (*profilev1.ProfileObject, error)
+	CreateProfile(
+		ctx context.Context,
+		request *profilev1.CreateRequest,
+	) (*profilev1.ProfileObject, error)
 
-	UpdateProfile(ctx context.Context, request *profilev1.UpdateRequest) (*profilev1.ProfileObject, error)
-	UpdateProfileProperties(ctx context.Context, profileID string, properties data.JSONMap, scoped bool) (*profilev1.ProfileObject, error)
+	UpdateProfile(
+		ctx context.Context,
+		request *profilev1.UpdateRequest,
+	) (*profilev1.ProfileObject, error)
+	UpdateProfileProperties(
+		ctx context.Context,
+		profileID string,
+		properties data.JSONMap,
+		scoped bool,
+	) (*profilev1.ProfileObject, error)
 
-	GetPropertyHistory(ctx context.Context, profileID, key, callerTenantID string) ([]*models.PropertyEntry, error)
+	GetPropertyHistory(
+		ctx context.Context,
+		profileID, key, callerTenantID string,
+	) ([]*models.PropertyEntry, error)
 
-	MergeProfile(ctx context.Context, request *profilev1.MergeRequest) (*profilev1.ProfileObject, error)
+	MergeProfile(
+		ctx context.Context,
+		request *profilev1.MergeRequest,
+	) (*profilev1.ProfileObject, error)
 
-	AddAddress(ctx context.Context, address *profilev1.AddAddressRequest) (*profilev1.ProfileObject, error)
+	AddAddress(
+		ctx context.Context,
+		address *profilev1.AddAddressRequest,
+	) (*profilev1.ProfileObject, error)
 
 	AddContact(
 		ctx context.Context,
@@ -64,7 +87,11 @@ type ProfileBusiness interface {
 		verificationID, code string,
 		expiryDuration time.Duration,
 	) (string, error)
-	CheckVerification(ctx context.Context, verificationID string, code, ipAddress string) (int, bool, error)
+	CheckVerification(
+		ctx context.Context,
+		verificationID string,
+		code, ipAddress string,
+	) (int, bool, error)
 	ToAPI(ctx context.Context, profile *models.Profile) (*profilev1.ProfileObject, error)
 }
 
@@ -298,7 +325,11 @@ func (pb *profileBusiness) GetByIDAndPartition(
 		return nil, err
 	}
 
-	scopedEntries, scopedErr := pb.propertyEntryRepo.LatestScopedByProfileAndPartition(ctx, profileID, partitionID)
+	scopedEntries, scopedErr := pb.propertyEntryRepo.LatestScopedByProfileAndPartition(
+		ctx,
+		profileID,
+		partitionID,
+	)
 	if scopedErr != nil {
 		return nil, data.ErrorConvertToAPI(scopedErr)
 	}
@@ -315,7 +346,10 @@ func (pb *profileBusiness) GetByIDAndPartition(
 	return profileObj, nil
 }
 
-func (pb *profileBusiness) GetPropertyHistory(ctx context.Context, profileID, key, callerTenantID string) ([]*models.PropertyEntry, error) {
+func (pb *profileBusiness) GetPropertyHistory(
+	ctx context.Context,
+	profileID, key, callerTenantID string,
+) ([]*models.PropertyEntry, error) {
 	return pb.propertyEntryRepo.HistoryByKey(ctx, profileID, key, callerTenantID)
 }
 
@@ -357,7 +391,10 @@ func (pb *profileBusiness) CreateProfile(
 	contactDetail := strings.TrimSpace(request.GetContact())
 
 	if contactDetail == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("contact details are invalid"))
+		return nil, connect.NewError(
+			connect.CodeInvalidArgument,
+			errors.New("contact details are invalid"),
+		)
 	}
 
 	p := models.Profile{}
@@ -456,7 +493,10 @@ func (pb *profileBusiness) AddContact(
 	request *profilev1.AddContactRequest) (*profilev1.ProfileObject, string, error) {
 	profileID := request.GetId()
 	if profileID == "" {
-		return nil, "", connect.NewError(connect.CodeInvalidArgument, errors.New("profile id is required"))
+		return nil, "", connect.NewError(
+			connect.CodeInvalidArgument,
+			errors.New("profile id is required"),
+		)
 	}
 
 	// Authorization is handled by the handler layer (owner check + contact_manage permission).
@@ -535,7 +575,13 @@ func (pb *profileBusiness) VerifyContact(
 		return "", err
 	}
 
-	verification, err := pb.contactBusiness.VerifyContact(ctx, contact, verificationID, code, expiryDuration)
+	verification, err := pb.contactBusiness.VerifyContact(
+		ctx,
+		contact,
+		verificationID,
+		code,
+		expiryDuration,
+	)
 	if err != nil {
 		return "", err
 	}

--- a/apps/default/service/business/roster_test.go
+++ b/apps/default/service/business/roster_test.go
@@ -454,6 +454,7 @@ func (rts *RosterTestSuite) TestRosterBusiness_Search() {
 	})
 }
 
+//nolint:gocognit // multi-scenario integration test; splitting hurts readability
 func (rts *RosterTestSuite) TestRosterBusiness_MultiList() {
 	t := rts.T()
 

--- a/apps/default/service/handlers/profiles.go
+++ b/apps/default/service/handlers/profiles.go
@@ -59,7 +59,14 @@ func NewProfileServer(
 	contactRepo := repository.NewContactRepository(ctx, dbPool, workMan)
 	verificationRepo := repository.NewVerificationRepository(ctx, dbPool, workMan)
 
-	contactBusiness := business.NewContactBusiness(ctx, cfg, dek, evtsMan, contactRepo, verificationRepo)
+	contactBusiness := business.NewContactBusiness(
+		ctx,
+		cfg,
+		dek,
+		evtsMan,
+		contactRepo,
+		verificationRepo,
+	)
 
 	addressRepo := repository.NewAddressRepository(ctx, dbPool, workMan)
 	addressBusiness := business.NewAddressBusiness(ctx, addressRepo)
@@ -154,7 +161,9 @@ func (ps *ProfileServer) Search(ctx context.Context,
 			if err1 != nil {
 				return errorutil.CleanErr(err1)
 			}
-			sErr := stream.Send(&profilev1.SearchResponse{Data: []*profilev1.ProfileObject{profileObject}})
+			sErr := stream.Send(
+				&profilev1.SearchResponse{Data: []*profilev1.ProfileObject{profileObject}},
+			)
 			if sErr != nil {
 				return errorutil.CleanErr(sErr)
 			}
@@ -215,7 +224,11 @@ func (ps *ProfileServer) GetByIDAndPartition(
 	ctx context.Context,
 	request *connect.Request[profilev1.GetByIDAndPartitionRequest],
 ) (*connect.Response[profilev1.GetByIDAndPartitionResponse], error) {
-	profileObj, err := ps.profileBusiness.GetByIDAndPartition(ctx, request.Msg.GetId(), request.Msg.GetPartitionId())
+	profileObj, err := ps.profileBusiness.GetByIDAndPartition(
+		ctx,
+		request.Msg.GetId(),
+		request.Msg.GetPartitionId(),
+	)
 	if err != nil {
 		return nil, errorutil.CleanErr(err)
 	}
@@ -235,7 +248,12 @@ func (ps *ProfileServer) PropertyHistory(
 		callerTenantID = claims.GetTenantID()
 	}
 
-	entries, err := ps.profileBusiness.GetPropertyHistory(ctx, request.Msg.GetId(), request.Msg.GetKey(), callerTenantID)
+	entries, err := ps.profileBusiness.GetPropertyHistory(
+		ctx,
+		request.Msg.GetId(),
+		request.Msg.GetKey(),
+		callerTenantID,
+	)
 	if err != nil {
 		return nil, errorutil.CleanErr(err)
 	}
@@ -256,8 +274,10 @@ func (ps *ProfileServer) PropertyHistory(
 }
 
 // AddAddress Adds a new address based on the request.
-func (ps *ProfileServer) AddAddress(ctx context.Context,
-	request *connect.Request[profilev1.AddAddressRequest]) (*connect.Response[profilev1.AddAddressResponse], error) {
+func (ps *ProfileServer) AddAddress(
+	ctx context.Context,
+	request *connect.Request[profilev1.AddAddressRequest],
+) (*connect.Response[profilev1.AddAddressResponse], error) {
 	claims := security.ClaimsFromContext(ctx)
 	if sub, _ := claims.GetSubject(); sub != request.Msg.GetId() {
 		if err := ps.checker.Check(ctx, "contact_manage"); err != nil {
@@ -307,7 +327,9 @@ func (ps *ProfileServer) AddContact(
 		Action:     auditlib.RelationAdded,
 	})
 
-	return connect.NewResponse(&profilev1.AddContactResponse{Data: profileObj, VerificationId: verificationID}), nil
+	return connect.NewResponse(
+		&profilev1.AddContactResponse{Data: profileObj, VerificationId: verificationID},
+	), nil
 }
 
 func (ps *ProfileServer) CreateContact(
@@ -475,7 +497,8 @@ func (ps *ProfileServer) SearchRoster(
 
 func (ps *ProfileServer) AddRoster(
 	ctx context.Context,
-	request *connect.Request[profilev1.AddRosterRequest]) (*connect.Response[profilev1.AddRosterResponse], error) {
+	request *connect.Request[profilev1.AddRosterRequest],
+) (*connect.Response[profilev1.AddRosterResponse], error) {
 	roster, err := ps.rosterBusiness.CreateRoster(ctx, request.Msg)
 
 	if err != nil {

--- a/apps/default/service/models/models_test.go
+++ b/apps/default/service/models/models_test.go
@@ -20,7 +20,11 @@ func TestProfileTypeIDToEnum(t *testing.T) {
 	}{
 		{"Person type", uint(profilev1.ProfileType_PERSON.Number()), profilev1.ProfileType_PERSON},
 		{"Bot type", uint(profilev1.ProfileType_BOT.Number()), profilev1.ProfileType_BOT},
-		{"Institution type", uint(profilev1.ProfileType_INSTITUTION.Number()), profilev1.ProfileType_INSTITUTION},
+		{
+			"Institution type",
+			uint(profilev1.ProfileType_INSTITUTION.Number()),
+			profilev1.ProfileType_INSTITUTION,
+		},
 		{"Unknown type defaults to Person", 999, profilev1.ProfileType_PERSON},
 		{"Zero type defaults to Person", 0, profilev1.ProfileType_PERSON},
 	}
@@ -40,8 +44,16 @@ func TestRelationshipTypeIDToEnum(t *testing.T) {
 		expected profilev1.RelationshipType
 	}{
 		{"Member type", models.RelationshipTypeMemberID, profilev1.RelationshipType_MEMBER},
-		{"Affiliated type", models.RelationshipTypeAffiliatedID, profilev1.RelationshipType_AFFILIATED},
-		{"Blacklisted type", models.RelationshipTypeBlackListedID, profilev1.RelationshipType_BLACK_LISTED},
+		{
+			"Affiliated type",
+			models.RelationshipTypeAffiliatedID,
+			profilev1.RelationshipType_AFFILIATED,
+		},
+		{
+			"Blacklisted type",
+			models.RelationshipTypeBlackListedID,
+			profilev1.RelationshipType_BLACK_LISTED,
+		},
 		{"Unknown type defaults to Member", 999, profilev1.RelationshipType_MEMBER},
 		{"Zero type defaults to Member", 0, profilev1.RelationshipType_MEMBER},
 	}
@@ -287,14 +299,30 @@ func TestRelationship_ToAPI(t *testing.T) {
 
 func TestProfileTypeIDMap(t *testing.T) {
 	// Verify the map contains expected entries
-	require.Equal(t, uint(profilev1.ProfileType_PERSON.Number()), models.ProfileTypeIDMap[profilev1.ProfileType_PERSON])
-	require.Equal(t, uint(profilev1.ProfileType_BOT.Number()), models.ProfileTypeIDMap[profilev1.ProfileType_BOT])
-	require.Equal(t, uint(profilev1.ProfileType_INSTITUTION.Number()), models.ProfileTypeIDMap[profilev1.ProfileType_INSTITUTION])
+	require.Equal(
+		t,
+		uint(profilev1.ProfileType_PERSON.Number()),
+		models.ProfileTypeIDMap[profilev1.ProfileType_PERSON],
+	)
+	require.Equal(
+		t,
+		uint(profilev1.ProfileType_BOT.Number()),
+		models.ProfileTypeIDMap[profilev1.ProfileType_BOT],
+	)
+	require.Equal(
+		t,
+		uint(profilev1.ProfileType_INSTITUTION.Number()),
+		models.ProfileTypeIDMap[profilev1.ProfileType_INSTITUTION],
+	)
 }
 
 func TestRelationshipTypeIDMap(t *testing.T) {
 	// Verify the map contains expected entries
-	require.Equal(t, models.RelationshipTypeMemberID, models.RelationshipTypeIDMap[profilev1.RelationshipType_MEMBER])
+	require.Equal(
+		t,
+		models.RelationshipTypeMemberID,
+		models.RelationshipTypeIDMap[profilev1.RelationshipType_MEMBER],
+	)
 	require.Equal(
 		t,
 		models.RelationshipTypeAffiliatedID,

--- a/apps/default/service/repository/addresses.go
+++ b/apps/default/service/repository/addresses.go
@@ -19,7 +19,11 @@ type addressRepository struct {
 	datastore.BaseRepository[*models.Address]
 }
 
-func NewAddressRepository(ctx context.Context, dbPool pool.Pool, workMan workerpool.Manager) AddressRepository {
+func NewAddressRepository(
+	ctx context.Context,
+	dbPool pool.Pool,
+	workMan workerpool.Manager,
+) AddressRepository {
 	repo := addressRepository{
 		BaseRepository: datastore.NewBaseRepository[*models.Address](
 			ctx, dbPool, workMan, func() *models.Address { return &models.Address{} },
@@ -28,7 +32,10 @@ func NewAddressRepository(ctx context.Context, dbPool pool.Pool, workMan workerp
 	return &repo
 }
 
-func (ar *addressRepository) SaveLink(ctx context.Context, profileAddress *models.ProfileAddress) error {
+func (ar *addressRepository) SaveLink(
+	ctx context.Context,
+	profileAddress *models.ProfileAddress,
+) error {
 	return ar.Pool().DB(ctx, false).Save(profileAddress).Error
 }
 
@@ -56,15 +63,26 @@ func (ar *addressRepository) GetByNameAdminUnitAndCountry(
 	return address, err
 }
 
-func (ar *addressRepository) GetByProfileID(ctx context.Context, id string) ([]*models.ProfileAddress, error) {
+func (ar *addressRepository) GetByProfileID(
+	ctx context.Context,
+	id string,
+) ([]*models.ProfileAddress, error) {
 	// Address-profile links are cross-tenant identity data. Skip tenancy scoping.
 	unscopedCtx := security.SkipTenancyChecksOnClaims(ctx)
 	var addressList []*models.ProfileAddress
-	err := ar.Pool().DB(unscopedCtx, true).Preload(clause.Associations).Where("profile_id = ?", id).Find(&addressList).Error
+	err := ar.Pool().
+		DB(unscopedCtx, true).
+		Preload(clause.Associations).
+		Where("profile_id = ?", id).
+		Find(&addressList).
+		Error
 	return addressList, err
 }
 
-func (ar *addressRepository) CountryGetByISO3(ctx context.Context, countryISO3 string) (*models.Country, error) {
+func (ar *addressRepository) CountryGetByISO3(
+	ctx context.Context,
+	countryISO3 string,
+) (*models.Country, error) {
 	// Countries are global seed data. Skip tenancy scoping.
 	unscopedCtx := security.SkipTenancyChecksOnClaims(ctx)
 	country := &models.Country{}
@@ -72,9 +90,15 @@ func (ar *addressRepository) CountryGetByISO3(ctx context.Context, countryISO3 s
 	return country, err
 }
 
-func (ar *addressRepository) CountryGetByAny(ctx context.Context, c string) (*models.Country, error) {
+func (ar *addressRepository) CountryGetByAny(
+	ctx context.Context,
+	c string,
+) (*models.Country, error) {
 	if c == "" {
-		return nil, connect.NewError(connect.CodeNotFound, errors.New("specified country does not exist"))
+		return nil, connect.NewError(
+			connect.CodeNotFound,
+			errors.New("specified country does not exist"),
+		)
 	}
 
 	// Countries are global seed data. Skip tenancy scoping.
@@ -89,10 +113,17 @@ func (ar *addressRepository) CountryGetByAny(ctx context.Context, c string) (*mo
 	return country, err
 }
 
-func (ar *addressRepository) CountryGetByName(ctx context.Context, name string) (*models.Country, error) {
+func (ar *addressRepository) CountryGetByName(
+	ctx context.Context,
+	name string,
+) (*models.Country, error) {
 	// Countries are global seed data. Skip tenancy scoping.
 	unscopedCtx := security.SkipTenancyChecksOnClaims(ctx)
 	country := &models.Country{}
-	err := ar.Pool().DB(unscopedCtx, true).Where("name = ilike", strings.ToUpper(name)).First(country).Error
+	err := ar.Pool().
+		DB(unscopedCtx, true).
+		Where("name = ilike", strings.ToUpper(name)).
+		First(country).
+		Error
 	return country, err
 }

--- a/apps/default/service/repository/interfaces.go
+++ b/apps/default/service/repository/interfaces.go
@@ -13,10 +13,16 @@ import (
 
 type ProfileRepository interface {
 	datastore.BaseRepository[*models.Profile]
-	Search(ctx context.Context, query *data.SearchQuery) (workerpool.JobResultPipe[[]*models.Profile], error)
+	Search(
+		ctx context.Context,
+		query *data.SearchQuery,
+	) (workerpool.JobResultPipe[[]*models.Profile], error)
 
 	GetTypeByID(ctx context.Context, profileTypeID string) (*models.ProfileType, error)
-	GetTypeByUID(ctx context.Context, profileType profilev1.ProfileType) (*models.ProfileType, error)
+	GetTypeByUID(
+		ctx context.Context,
+		profileType profilev1.ProfileType,
+	) (*models.ProfileType, error)
 }
 
 type ContactRepository interface {
@@ -35,11 +41,28 @@ type VerificationRepository interface {
 
 type RosterRepository interface {
 	datastore.BaseRepository[*models.Roster]
-	GetByContactAndProfileID(ctx context.Context, profileID, contactID string) (*models.Roster, error)
-	GetByContactIDsAndProfileID(ctx context.Context, contactIDs []string, profileID string) ([]*models.Roster, error)
-	GetByContactAndProfileIDAndName(ctx context.Context, profileID, contactID, name string) (*models.Roster, error)
-	GetByContactIDsAndProfileIDAndName(ctx context.Context, contactIDs []string, profileID, name string) ([]*models.Roster, error)
-	Search(ctx context.Context, query *data.SearchQuery) (workerpool.JobResultPipe[[]*models.Roster], error)
+	GetByContactAndProfileID(
+		ctx context.Context,
+		profileID, contactID string,
+	) (*models.Roster, error)
+	GetByContactIDsAndProfileID(
+		ctx context.Context,
+		contactIDs []string,
+		profileID string,
+	) ([]*models.Roster, error)
+	GetByContactAndProfileIDAndName(
+		ctx context.Context,
+		profileID, contactID, name string,
+	) (*models.Roster, error)
+	GetByContactIDsAndProfileIDAndName(
+		ctx context.Context,
+		contactIDs []string,
+		profileID, name string,
+	) ([]*models.Roster, error)
+	Search(
+		ctx context.Context,
+		query *data.SearchQuery,
+	) (workerpool.JobResultPipe[[]*models.Roster], error)
 }
 
 type AddressRepository interface {
@@ -64,8 +87,14 @@ type PropertyEntryRepository interface {
 	datastore.BaseRepository[*models.PropertyEntry]
 	AppendEntries(ctx context.Context, entries []*models.PropertyEntry) error
 	LatestGlobalByProfile(ctx context.Context, profileID string) ([]*models.PropertyEntry, error)
-	LatestScopedByProfileAndPartition(ctx context.Context, profileID, partitionID string) ([]*models.PropertyEntry, error)
-	HistoryByKey(ctx context.Context, profileID, key, callerTenantID string) ([]*models.PropertyEntry, error)
+	LatestScopedByProfileAndPartition(
+		ctx context.Context,
+		profileID, partitionID string,
+	) ([]*models.PropertyEntry, error)
+	HistoryByKey(
+		ctx context.Context,
+		profileID, key, callerTenantID string,
+	) ([]*models.PropertyEntry, error)
 }
 
 type RelationshipRepository interface {
@@ -76,6 +105,12 @@ type RelationshipRepository interface {
 		lastRelationshipID string, count int,
 	) ([]*models.Relationship, error)
 
-	RelationshipType(ctx context.Context, relationshipType profilev1.RelationshipType) (*models.RelationshipType, error)
-	RelationshipTypeByID(ctx context.Context, relationshipTypeID string) (*models.RelationshipType, error)
+	RelationshipType(
+		ctx context.Context,
+		relationshipType profilev1.RelationshipType,
+	) (*models.RelationshipType, error)
+	RelationshipTypeByID(
+		ctx context.Context,
+		relationshipTypeID string,
+	) (*models.RelationshipType, error)
 }

--- a/apps/default/service/repository/property_entries.go
+++ b/apps/default/service/repository/property_entries.go
@@ -15,7 +15,11 @@ type propertyEntryRepository struct {
 	datastore.BaseRepository[*models.PropertyEntry]
 }
 
-func NewPropertyEntryRepository(ctx context.Context, dbPool pool.Pool, workMan workerpool.Manager) PropertyEntryRepository {
+func NewPropertyEntryRepository(
+	ctx context.Context,
+	dbPool pool.Pool,
+	workMan workerpool.Manager,
+) PropertyEntryRepository {
 	return &propertyEntryRepository{
 		BaseRepository: datastore.NewBaseRepository[*models.PropertyEntry](
 			ctx, dbPool, workMan, func() *models.PropertyEntry { return &models.PropertyEntry{} },
@@ -24,12 +28,18 @@ func NewPropertyEntryRepository(ctx context.Context, dbPool pool.Pool, workMan w
 }
 
 // AppendEntries writes property entries with raw ctx to stamp tenant provenance.
-func (r *propertyEntryRepository) AppendEntries(ctx context.Context, entries []*models.PropertyEntry) error {
+func (r *propertyEntryRepository) AppendEntries(
+	ctx context.Context,
+	entries []*models.PropertyEntry,
+) error {
 	return r.Pool().DB(ctx, false).Create(&entries).Error
 }
 
 // LatestGlobalByProfile returns the latest global (scoped=false) entry per key.
-func (r *propertyEntryRepository) LatestGlobalByProfile(ctx context.Context, profileID string) ([]*models.PropertyEntry, error) {
+func (r *propertyEntryRepository) LatestGlobalByProfile(
+	ctx context.Context,
+	profileID string,
+) ([]*models.PropertyEntry, error) {
 	unscopedCtx := security.SkipTenancyChecksOnClaims(ctx)
 	var entries []*models.PropertyEntry
 	err := r.Pool().DB(unscopedCtx, true).
@@ -41,7 +51,10 @@ func (r *propertyEntryRepository) LatestGlobalByProfile(ctx context.Context, pro
 }
 
 // LatestScopedByProfileAndPartition returns latest scoped entries per key for a partition.
-func (r *propertyEntryRepository) LatestScopedByProfileAndPartition(ctx context.Context, profileID, partitionID string) ([]*models.PropertyEntry, error) {
+func (r *propertyEntryRepository) LatestScopedByProfileAndPartition(
+	ctx context.Context,
+	profileID, partitionID string,
+) ([]*models.PropertyEntry, error) {
 	unscopedCtx := security.SkipTenancyChecksOnClaims(ctx)
 	var entries []*models.PropertyEntry
 	err := r.Pool().DB(unscopedCtx, true).
@@ -54,7 +67,10 @@ func (r *propertyEntryRepository) LatestScopedByProfileAndPartition(ctx context.
 
 // HistoryByKey returns all entries for a profile+key, most recent first.
 // Scoped entries are filtered to the caller's tenant.
-func (r *propertyEntryRepository) HistoryByKey(ctx context.Context, profileID, key, callerTenantID string) ([]*models.PropertyEntry, error) {
+func (r *propertyEntryRepository) HistoryByKey(
+	ctx context.Context,
+	profileID, key, callerTenantID string,
+) ([]*models.PropertyEntry, error) {
 	unscopedCtx := security.SkipTenancyChecksOnClaims(ctx)
 	var entries []*models.PropertyEntry
 	err := r.Pool().DB(unscopedCtx, true).

--- a/apps/default/service/repository/property_entries.go
+++ b/apps/default/service/repository/property_entries.go
@@ -76,7 +76,10 @@ func (r *propertyEntryRepository) HistoryByKey(
 	err := r.Pool().DB(unscopedCtx, true).
 		Where("profile_id = ? AND key = ? AND (scoped = FALSE OR tenant_id = ?) AND deleted_at IS NULL",
 			profileID, key, callerTenantID).
-		Order("created_at DESC").
+		// id is an xid, so it breaks created_at ties (xid second-resolution
+		// timestamp means two entries written in the same second share
+		// created_at but remain sortable by id).
+		Order("created_at DESC, id DESC").
 		Find(&entries).Error
 	return entries, err
 }

--- a/apps/geolocation/migrations/0001/011_geo_events_composite_pk_down.sql
+++ b/apps/geolocation/migrations/0001/011_geo_events_composite_pk_down.sql
@@ -1,0 +1,4 @@
+-- Copyright 2023-2026 Ant Investor Ltd
+
+ALTER TABLE geo_events DROP CONSTRAINT IF EXISTS geo_events_pkey;
+ALTER TABLE geo_events ADD PRIMARY KEY (id);

--- a/apps/geolocation/migrations/0001/011_geo_events_composite_pk_up.sql
+++ b/apps/geolocation/migrations/0001/011_geo_events_composite_pk_up.sql
@@ -1,0 +1,12 @@
+-- Copyright 2023-2026 Ant Investor Ltd
+--
+-- Licensed under the Apache License, Version 2.0 (the "License").
+
+-- geo_events is promoted to a TimescaleDB hypertable. TimescaleDB requires
+-- the time-partition column to participate in every UNIQUE/PRIMARY
+-- constraint, so replace the BaseModel-default PK (id) with a composite
+-- (id, true_created_at). Client-captured event timestamps are the
+-- correctness-critical ordering dimension for offline-batched uploads.
+
+ALTER TABLE geo_events DROP CONSTRAINT IF EXISTS geo_events_pkey;
+ALTER TABLE geo_events ADD PRIMARY KEY (id, true_created_at);

--- a/apps/geolocation/service/models/models.go
+++ b/apps/geolocation/service/models/models.go
@@ -313,9 +313,8 @@ func (r *Route) ToAPI() *RouteAPI {
 	}
 	api.DeviationThresholdM = r.DeviationThresholdM
 	if r.DeviationConsecutiveCount != nil {
-		value := int32(
-			*r.DeviationConsecutiveCount,
-		) //nolint:gosec // bounded by business validation
+		//nolint:gosec // bounded by business validation
+		value := int32(*r.DeviationConsecutiveCount)
 		api.DeviationConsecutiveCount = &value
 	}
 	if r.DeviationCooldownSec != nil {

--- a/apps/geolocation/service/models/models.go
+++ b/apps/geolocation/service/models/models.go
@@ -112,7 +112,7 @@ type LocationPoint struct {
 	ProcessingState LocationPointProcessingState `gorm:"type:smallint;not null;default:0;index:idx_lp_processing_state"`
 	ProcessedAt     *time.Time                   `gorm:"type:timestamptz"`
 	ProcessingError string                       `gorm:"type:text;not null;default:''"`
-	Geom            *string                      `gorm:"type:geometry(Point,4326);column:geom"                                 json:"-"`
+	Geom            *string                      `gorm:"type:geometry(Point,4326);column:geom"                                                           json:"-"`
 }
 
 func (*LocationPoint) TableName() string {
@@ -313,7 +313,9 @@ func (r *Route) ToAPI() *RouteAPI {
 	}
 	api.DeviationThresholdM = r.DeviationThresholdM
 	if r.DeviationConsecutiveCount != nil {
-		value := int32(*r.DeviationConsecutiveCount) //nolint:gosec // bounded by business validation
+		value := int32(
+			*r.DeviationConsecutiveCount,
+		) //nolint:gosec // bounded by business validation
 		api.DeviationConsecutiveCount = &value
 	}
 	if r.DeviationCooldownSec != nil {

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/google/gnostic v0.7.1
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/mssola/user_agent v0.6.0
-	github.com/pitabwire/frame v1.94.4
+	github.com/pitabwire/frame v1.94.6
 	github.com/pitabwire/util v0.8.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
@@ -107,7 +107,7 @@ require (
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
 	github.com/moby/moby/api v1.54.2 // indirect
-	github.com/moby/moby/client v0.4.0 // indirect
+	github.com/moby/moby/client v0.4.1 // indirect
 	github.com/moby/patternmatcher v0.6.1 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/user v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/moby/go-archive v0.2.0 h1:zg5QDUM2mi0JIM9fdQZWC7U8+2ZfixfTYoHL7rWUcP8
 github.com/moby/go-archive v0.2.0/go.mod h1:mNeivT14o8xU+5q1YnNrkQVpK+dnNe/K6fHqnTg4qPU=
 github.com/moby/moby/api v1.54.2 h1:wiat9QAhnDQjA7wk1kh/TqHz2I1uUA7M7t9SAl/JNXg=
 github.com/moby/moby/api v1.54.2/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
-github.com/moby/moby/client v0.4.0 h1:S+2XegzHQrrvTCvF6s5HFzcrywWQmuVnhOXe2kiWjIw=
-github.com/moby/moby/client v0.4.0/go.mod h1:QWPbvWchQbxBNdaLSpoKpCdf5E+WxFAgNHogCWDoa7g=
+github.com/moby/moby/client v0.4.1 h1:DMQgisVoMkmMs7fp3ROSdiBnoAu8+vo3GggFl06M/wY=
+github.com/moby/moby/client v0.4.1/go.mod h1:z52C9O2POPOsnxZAy//WtKcQ32P+jT/NGeXu/7nfjGQ=
 github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=
 github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7zgvCU=
@@ -254,8 +254,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.0 h1:u9JhESo83i/GkZnhfTNuFMMWcNt7mnV1bGJ6FT4wXH8=
 github.com/panjf2000/ants/v2 v2.12.0/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame v1.94.4 h1:4KgbhY44nUOk3l7BYYd9qZlq7vBxOGP5YBS7VzQUYQU=
-github.com/pitabwire/frame v1.94.4/go.mod h1:ZK/YaGUEpltB71XFf8dCAfXLRKY5QcAO9Mnya+B/ra8=
+github.com/pitabwire/frame v1.94.6 h1:CJJdo6+jvL53yp5HaEhrGsaAE48BVmpBD1PRXzRmt3g=
+github.com/pitabwire/frame v1.94.6/go.mod h1:5tyetk1wosnb/KW+54IHKcogm1VIKmdurYW1JjcSqaA=
 github.com/pitabwire/natspubsub v0.8.2 h1:kzNas93jIsFLiHHJm24j7c0XBLsR9zkuVLqvnhE0Si8=
 github.com/pitabwire/natspubsub v0.8.2/go.mod h1:jKluv8iY22EEn2oRjqU/rURBOj+56SJmeOd5+AxknSQ=
 github.com/pitabwire/util v0.8.0 h1:LNKCTMmfurjk4ShG1peTuMFGsOAR5o5jIZ84lHNvwlU=


### PR DESCRIPTION
## Summary

TimescaleDB requires the time-partition column in every UNIQUE/PRIMARY
constraint. \`geo_events\` is registered as a hypertable; this migration
swaps \`PRIMARY KEY (id)\` for \`PRIMARY KEY (id, true_created_at)\` so
common/timescale.Ensure can convert it at startup.

\`location_points\` is NOT changed here — migration 007 already creates
that table as PG-partitioned with composite \`(id, true_created_at)\`.

## Test plan

- [x] go build ./...
- [x] go test ./apps/geolocation/service/repository/...
- [ ] CI green before merge