### PR TITLE
feat: wire frame v1.95.0 transparent tenancy interceptor

### DIFF
--- a/apps/default/cmd/main.go
+++ b/apps/default/cmd/main.go
@@ -246,6 +246,7 @@ func seedDefaultData(ctx context.Context, svc *frame.Service, dek *aconfig.DEK) 
 func setupConnectServer(ctx context.Context, svc *frame.Service, dek *aconfig.DEK,
 	notificationCli notificationv1connect.NotificationServiceClient) http.Handler {
 	securityMan := svc.SecurityManager()
+	dbPool := svc.DatastoreManager().GetPool(ctx, datastore.DefaultPoolName)
 
 	authenticator := securityMan.GetAuthenticator(ctx)
 
@@ -296,12 +297,21 @@ func setupConnectServer(ctx context.Context, svc *frame.Service, dek *aconfig.DE
 		auditInterceptor = audit.NewInterceptor("service_profile", nil)
 	}
 
+	// TenancyTxInterceptor opens a request-scoped transaction after auth
+	// has populated the claims, publishes app.tenant_id + app.partition_id
+	// from the claims via set_config, and binds the transaction to the
+	// request context. Repository code then calls pool.DB(ctx, _) and gets
+	// the bound tx transparently; tenancy is enforced by Row-Level Security
+	// at the database layer.
+	tenancyTxInterceptor := connectInterceptors.NewTenancyTxInterceptor(dbPool)
+
 	defaultInterceptorList, err := connectInterceptors.DefaultList(
 		ctx,
 		authenticator,
 		tenancyAccessInterceptor,
 		functionAccessInterceptor,
 		auditInterceptor,
+		tenancyTxInterceptor,
 	)
 	if err != nil {
 		util.Log(ctx).WithError(err).Fatal("main -- Could not create default interceptors")

--- a/apps/devices/cmd/main.go
+++ b/apps/devices/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pitabwire/frame"
 	"github.com/pitabwire/frame/config"
 	"github.com/pitabwire/frame/datastore"
+	"github.com/pitabwire/frame/datastore/pool"
 	"github.com/pitabwire/frame/security"
 	"github.com/pitabwire/frame/security/authorizer"
 	connectInterceptors "github.com/pitabwire/frame/security/interceptors/connect"
@@ -119,7 +120,7 @@ func initServiceComponents(
 
 	implementation := handlers.NewDeviceServer(ctx, functionChecker, deviceBusiness, presenceBusiness, keyBusiness,
 		notifyBusiness, turnBiz, cacheSvc, cfg.TURNTTL, cfg.RateLimitTURNPerMinute)
-	connectHandler := setupConnectServer(ctx, securityMan, functionChecker, implementation)
+	connectHandler := setupConnectServer(ctx, securityMan, dbPool, functionChecker, implementation)
 
 	analysisHandler := queue.NewDeviceAnalysisQueueHandler(
 		httpClientMan, deviceRepo, deviceLogRepo, deviceSessionRepo, cacheSvc,
@@ -137,6 +138,7 @@ func initServiceComponents(
 func setupConnectServer(
 	ctx context.Context,
 	securityMan security.Manager,
+	dbPool pool.Pool,
 	functionChecker *authorizer.FunctionChecker,
 	implementation *handlers.DevicesServer,
 ) http.Handler {
@@ -156,11 +158,20 @@ func setupConnectServer(
 
 	functionAccessInterceptor := connectInterceptors.NewFunctionAccessInterceptor(functionChecker, procMap)
 
+	// TenancyTxInterceptor opens a request-scoped transaction after auth
+	// has populated the claims, publishes app.tenant_id + app.partition_id
+	// from the claims via set_config, and binds the transaction to the
+	// request context. Repository code then calls pool.DB(ctx, _) and gets
+	// the bound tx transparently; tenancy is enforced by Row-Level Security
+	// at the database layer.
+	tenancyTxInterceptor := connectInterceptors.NewTenancyTxInterceptor(dbPool)
+
 	defaultInterceptorList, err := connectInterceptors.DefaultList(
 		ctx,
 		authenticator,
 		tenancyAccessInterceptor,
 		functionAccessInterceptor,
+		tenancyTxInterceptor,
 	)
 	if err != nil {
 		util.Log(ctx).WithError(err).Fatal("main -- Could not create default interceptors")

--- a/apps/geolocation/cmd/main.go
+++ b/apps/geolocation/cmd/main.go
@@ -131,7 +131,7 @@ func main() { //nolint:funlen // wiring function
 	rl := handlers.NewRateLimitMiddleware(cfg.RateLimitConfig())
 	defer rl.Stop()
 
-	connectHandler := setupConnectServer(ctx, sm, functionChecker, geoServer)
+	connectHandler := setupConnectServer(ctx, sm, dbPool, functionChecker, geoServer)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", geoServer.HealthCheck)
@@ -170,6 +170,7 @@ func ensureHypertables(ctx context.Context, dbPool pool.Pool) {
 func setupConnectServer(
 	ctx context.Context,
 	sm security.Manager,
+	dbPool pool.Pool,
 	functionChecker *authorizer.FunctionChecker,
 	implementation *handlers.GeolocationServer,
 ) http.Handler {
@@ -192,11 +193,20 @@ func setupConnectServer(
 
 	functionAccessInterceptor := connectInterceptors.NewFunctionAccessInterceptor(functionChecker, procMap)
 
+	// TenancyTxInterceptor opens a request-scoped transaction after auth
+	// has populated the claims, publishes app.tenant_id + app.partition_id
+	// from the claims via set_config, and binds the transaction to the
+	// request context. Repository code then calls pool.DB(ctx, _) and gets
+	// the bound tx transparently; tenancy is enforced by Row-Level Security
+	// at the database layer.
+	tenancyTxInterceptor := connectInterceptors.NewTenancyTxInterceptor(dbPool)
+
 	defaultInterceptorList, err := connectInterceptors.DefaultList(
 		ctx,
 		authenticator,
 		tenancyAccessInterceptor,
 		functionAccessInterceptor,
+		tenancyTxInterceptor,
 	)
 	if err != nil {
 		util.Log(ctx).WithError(err).Fatal("main -- Could not create default interceptors")

--- a/apps/settings/cmd/main.go
+++ b/apps/settings/cmd/main.go
@@ -88,6 +88,7 @@ func handleDatabaseMigration(
 // setupConnectServer initializes and configures the gRPC server.
 func setupConnectServer(ctx context.Context, svc *frame.Service) http.Handler {
 	securityMan := svc.SecurityManager()
+	dbPool := svc.DatastoreManager().GetPool(ctx, datastore.DefaultPoolName)
 
 	authenticator := securityMan.GetAuthenticator(ctx)
 
@@ -102,11 +103,20 @@ func setupConnectServer(ctx context.Context, svc *frame.Service) http.Handler {
 	functionChecker := authorizer.NewFunctionChecker(auth, permissions.ForService(sd).Namespace)
 	functionAccessInterceptor := connectInterceptors.NewFunctionAccessInterceptor(functionChecker, procMap)
 
+	// TenancyTxInterceptor opens a request-scoped transaction after auth
+	// has populated the claims, publishes app.tenant_id + app.partition_id
+	// from the claims via set_config, and binds the transaction to the
+	// request context. Repository code then calls pool.DB(ctx, _) and gets
+	// the bound tx transparently; tenancy is enforced by Row-Level Security
+	// at the database layer.
+	tenancyTxInterceptor := connectInterceptors.NewTenancyTxInterceptor(dbPool)
+
 	defaultInterceptorList, err := connectInterceptors.DefaultList(
 		ctx,
 		authenticator,
 		tenancyAccessInterceptor,
 		functionAccessInterceptor,
+		tenancyTxInterceptor,
 	)
 	if err != nil {
 		util.Log(ctx).WithError(err).Fatal("main -- Could not create default interceptors")

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/google/gnostic v0.7.1
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/mssola/user_agent v0.6.0
-	github.com/pitabwire/frame v1.94.7
+	github.com/pitabwire/frame v1.95.0
 	github.com/pitabwire/util v0.9.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.0 h1:u9JhESo83i/GkZnhfTNuFMMWcNt7mnV1bGJ6FT4wXH8=
 github.com/panjf2000/ants/v2 v2.12.0/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame v1.94.7 h1:q9nnI79OX7YpVEdchS12VE4ZE37Rx0CVNfaoFJrA64M=
-github.com/pitabwire/frame v1.94.7/go.mod h1:VgKY5c3wGtl4ij4iIwUB3EdSXPPyV0Xj+PacmRIN38s=
+github.com/pitabwire/frame v1.95.0 h1:DfQ85WyPaRnFDSlN/IWsjJc8zBIeciiUjxNVEbqW338=
+github.com/pitabwire/frame v1.95.0/go.mod h1:VgKY5c3wGtl4ij4iIwUB3EdSXPPyV0Xj+PacmRIN38s=
 github.com/pitabwire/natspubsub v0.8.3 h1:VFc73S+qBgxKDgD1ZW6Hz/wKu/8ao/uA1JG38a7MWfc=
 github.com/pitabwire/natspubsub v0.8.3/go.mod h1:W5FT+Am26dmKAKYtMsKQfEeqEUi7O16bpl0UTFlQEA0=
 github.com/pitabwire/util v0.9.0 h1:fnlTAuWKqAjc6GalO+a7hMeo6g3fAv5yjmaP237ChP4=


### PR DESCRIPTION
## Summary

- Bump `github.com/pitabwire/frame` to **v1.95.0**.
- Drop the local `replace github.com/pitabwire/frame => /home/j/code/pitabwire/frame` directive.
- Register `connectInterceptors.NewTenancyTxInterceptor(dbPool)` in each app's Connect interceptor chain.

The interceptor opens a request-scoped Postgres transaction populated with the resolved partition/tenant claims, so repository code no longer has to thread tenancy state manually (transparent multi-partition tenancy via RLS + session vars).

Frame release: https://github.com/pitabwire/frame/tree/v1.95.0

## Test plan

- [ ] CI green
- [ ] Connect handlers still serve requests under expected tenant scope