### PR TITLE
chore(deps): migrate to frame v1.96.0 + natspubsub v0.8.4

### DIFF
--- a/apps/default/cmd/main.go
+++ b/apps/default/cmd/main.go
@@ -246,7 +246,6 @@ func seedDefaultData(ctx context.Context, svc *frame.Service, dek *aconfig.DEK) 
 func setupConnectServer(ctx context.Context, svc *frame.Service, dek *aconfig.DEK,
 	notificationCli notificationv1connect.NotificationServiceClient) http.Handler {
 	securityMan := svc.SecurityManager()
-	dbPool := svc.DatastoreManager().GetPool(ctx, datastore.DefaultPoolName)
 
 	authenticator := securityMan.GetAuthenticator(ctx)
 
@@ -297,21 +296,12 @@ func setupConnectServer(ctx context.Context, svc *frame.Service, dek *aconfig.DE
 		auditInterceptor = audit.NewInterceptor("service_profile", nil)
 	}
 
-	// TenancyTxInterceptor opens a request-scoped transaction after auth
-	// has populated the claims, publishes app.tenant_id + app.partition_id
-	// from the claims via set_config, and binds the transaction to the
-	// request context. Repository code then calls pool.DB(ctx, _) and gets
-	// the bound tx transparently; tenancy is enforced by Row-Level Security
-	// at the database layer.
-	tenancyTxInterceptor := connectInterceptors.NewTenancyTxInterceptor(dbPool)
-
 	defaultInterceptorList, err := connectInterceptors.DefaultList(
 		ctx,
 		authenticator,
 		tenancyAccessInterceptor,
 		functionAccessInterceptor,
 		auditInterceptor,
-		tenancyTxInterceptor,
 	)
 	if err != nil {
 		util.Log(ctx).WithError(err).Fatal("main -- Could not create default interceptors")

--- a/apps/devices/cmd/main.go
+++ b/apps/devices/cmd/main.go
@@ -158,20 +158,11 @@ func setupConnectServer(
 
 	functionAccessInterceptor := connectInterceptors.NewFunctionAccessInterceptor(functionChecker, procMap)
 
-	// TenancyTxInterceptor opens a request-scoped transaction after auth
-	// has populated the claims, publishes app.tenant_id + app.partition_id
-	// from the claims via set_config, and binds the transaction to the
-	// request context. Repository code then calls pool.DB(ctx, _) and gets
-	// the bound tx transparently; tenancy is enforced by Row-Level Security
-	// at the database layer.
-	tenancyTxInterceptor := connectInterceptors.NewTenancyTxInterceptor(dbPool)
-
 	defaultInterceptorList, err := connectInterceptors.DefaultList(
 		ctx,
 		authenticator,
 		tenancyAccessInterceptor,
 		functionAccessInterceptor,
-		tenancyTxInterceptor,
 	)
 	if err != nil {
 		util.Log(ctx).WithError(err).Fatal("main -- Could not create default interceptors")

--- a/apps/geolocation/cmd/main.go
+++ b/apps/geolocation/cmd/main.go
@@ -193,20 +193,11 @@ func setupConnectServer(
 
 	functionAccessInterceptor := connectInterceptors.NewFunctionAccessInterceptor(functionChecker, procMap)
 
-	// TenancyTxInterceptor opens a request-scoped transaction after auth
-	// has populated the claims, publishes app.tenant_id + app.partition_id
-	// from the claims via set_config, and binds the transaction to the
-	// request context. Repository code then calls pool.DB(ctx, _) and gets
-	// the bound tx transparently; tenancy is enforced by Row-Level Security
-	// at the database layer.
-	tenancyTxInterceptor := connectInterceptors.NewTenancyTxInterceptor(dbPool)
-
 	defaultInterceptorList, err := connectInterceptors.DefaultList(
 		ctx,
 		authenticator,
 		tenancyAccessInterceptor,
 		functionAccessInterceptor,
-		tenancyTxInterceptor,
 	)
 	if err != nil {
 		util.Log(ctx).WithError(err).Fatal("main -- Could not create default interceptors")

--- a/apps/settings/cmd/main.go
+++ b/apps/settings/cmd/main.go
@@ -88,7 +88,6 @@ func handleDatabaseMigration(
 // setupConnectServer initializes and configures the gRPC server.
 func setupConnectServer(ctx context.Context, svc *frame.Service) http.Handler {
 	securityMan := svc.SecurityManager()
-	dbPool := svc.DatastoreManager().GetPool(ctx, datastore.DefaultPoolName)
 
 	authenticator := securityMan.GetAuthenticator(ctx)
 
@@ -103,20 +102,11 @@ func setupConnectServer(ctx context.Context, svc *frame.Service) http.Handler {
 	functionChecker := authorizer.NewFunctionChecker(auth, permissions.ForService(sd).Namespace)
 	functionAccessInterceptor := connectInterceptors.NewFunctionAccessInterceptor(functionChecker, procMap)
 
-	// TenancyTxInterceptor opens a request-scoped transaction after auth
-	// has populated the claims, publishes app.tenant_id + app.partition_id
-	// from the claims via set_config, and binds the transaction to the
-	// request context. Repository code then calls pool.DB(ctx, _) and gets
-	// the bound tx transparently; tenancy is enforced by Row-Level Security
-	// at the database layer.
-	tenancyTxInterceptor := connectInterceptors.NewTenancyTxInterceptor(dbPool)
-
 	defaultInterceptorList, err := connectInterceptors.DefaultList(
 		ctx,
 		authenticator,
 		tenancyAccessInterceptor,
 		functionAccessInterceptor,
-		tenancyTxInterceptor,
 	)
 	if err != nil {
 		util.Log(ctx).WithError(err).Fatal("main -- Could not create default interceptors")

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/google/gnostic v0.7.1
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/mssola/user_agent v0.6.0
-	github.com/pitabwire/frame v1.95.0
+	github.com/pitabwire/frame v1.96.0
 	github.com/pitabwire/util v0.9.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
@@ -124,7 +124,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 // indirect
 	github.com/panjf2000/ants/v2 v2.12.0 // indirect
-	github.com/pitabwire/natspubsub v0.8.3 // indirect
+	github.com/pitabwire/natspubsub v0.8.4 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect

--- a/go.sum
+++ b/go.sum
@@ -256,10 +256,10 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.0 h1:u9JhESo83i/GkZnhfTNuFMMWcNt7mnV1bGJ6FT4wXH8=
 github.com/panjf2000/ants/v2 v2.12.0/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame v1.95.0 h1:DfQ85WyPaRnFDSlN/IWsjJc8zBIeciiUjxNVEbqW338=
-github.com/pitabwire/frame v1.95.0/go.mod h1:VgKY5c3wGtl4ij4iIwUB3EdSXPPyV0Xj+PacmRIN38s=
-github.com/pitabwire/natspubsub v0.8.3 h1:VFc73S+qBgxKDgD1ZW6Hz/wKu/8ao/uA1JG38a7MWfc=
-github.com/pitabwire/natspubsub v0.8.3/go.mod h1:W5FT+Am26dmKAKYtMsKQfEeqEUi7O16bpl0UTFlQEA0=
+github.com/pitabwire/frame v1.96.0 h1:99oLHTXAGeJVelOV24XaeOodjSD7lb5xG82MY8heN38=
+github.com/pitabwire/frame v1.96.0/go.mod h1:1g8nT+Atfp0thB4yC3iuIBUhvRxXmsKbih39SYbEsmo=
+github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
+github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.0 h1:fnlTAuWKqAjc6GalO+a7hMeo6g3fAv5yjmaP237ChP4=
 github.com/pitabwire/util v0.9.0/go.mod h1:JrLiS3K4VXsLZE38LLvq1N0X2j0fs33QLz/zMXf3zc4=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=


### PR DESCRIPTION
## Summary

- Bumps `github.com/pitabwire/frame` to **v1.96.0** (pluggable tenancy/RLS).
- Bumps `github.com/pitabwire/natspubsub` to **v0.8.4**.
- Removes manual `connectInterceptors.NewTenancyTxInterceptor(dbPool)` wiring where present — v1.96.0's `DefaultList` now auto-includes `tenancy.NewClaimsInterceptor()`.
- (service-fintech only) Removes `datastore/scopes` usages; RLS now enforces tenancy at the connection-acquire layer. Cross-tenant reapers/archival use `tenancy.WithSkipEnforcement(ctx)`.

## Frame v1.96.0 breaking changes
- Removed `Pool.WithTenancy`, `Pool.WithRequestTx`, `ContextWithTx`, `TxFromContext`.
- Removed `NewTenancyTxInterceptor` (auto-included now).
- Removed `datastore/scopes` package — RLS replaces it.
- New `tenancy/` package: `Claims`, `Provider`, `WithExtraPartitions`, `WithSkipEnforcement`, `NewClaimsInterceptor`.
- New `datastore/dialect/` abstraction.

## Operational note
**Postgres superuser bypasses RLS** even with `FORCE` — services must connect with a non-superuser role in production. See `frame/docs/datastore.md`.

## Test plan
- [ ] CI green
- [ ] Verify production DB role is non-superuser without `BYPASSRLS`