### PR TITLE
fix(geolocation): register OPL under service_geolocation, not service_profile

### DIFF
--- a/apps/devices/service/authz/role_mapping.go
+++ b/apps/devices/service/authz/role_mapping.go
@@ -3,7 +3,7 @@ package authz
 import "github.com/pitabwire/frame/security"
 
 const (
-	NamespaceProfile       = "service_profile"
+	NamespaceDevice        = "service_device"
 	NamespaceTenancyAccess = "tenancy_access"
 	NamespaceProfileUser   = "profile_user"
 )
@@ -76,7 +76,7 @@ func BuildServiceAccessTuple(tenancyPath, profileID string) security.RelationTup
 // role directly, so explicit granted_* tuples per permission are redundant.
 func BuildServiceInheritanceTuples(tenancyPath string) []security.RelationTuple {
 	return []security.RelationTuple{{
-		Object:   security.ObjectRef{Namespace: NamespaceProfile, ID: tenancyPath},
+		Object:   security.ObjectRef{Namespace: NamespaceDevice, ID: tenancyPath},
 		Relation: RoleService,
 		Subject: security.SubjectRef{
 			Namespace: NamespaceTenancyAccess,

--- a/apps/devices/tests/base_testsuite.go
+++ b/apps/devices/tests/base_testsuite.go
@@ -183,7 +183,7 @@ func (bs *DeviceBaseTestSuite) CreateService(
 
 	// Wire real Keto authoriser via SecurityManager
 	sm := svc.SecurityManager()
-	bs.FunctionChecker = authorizer.NewFunctionChecker(sm.GetAuthorizer(ctx), "service_profile")
+	bs.FunctionChecker = authorizer.NewFunctionChecker(sm.GetAuthorizer(ctx), "service_device")
 
 	depsBuilder := BuildRepos(ctx, svc)
 
@@ -239,7 +239,7 @@ func (bs *DeviceBaseTestSuite) SeedTenantAccess(
 	bs.Require().NoError(err, "failed to seed tenant access")
 }
 
-// SeedTenantRole writes functional permission tuples in the service_profile
+// SeedTenantRole writes functional permission tuples in the service_device
 // namespace for the given role.
 func (bs *DeviceBaseTestSuite) SeedTenantRole(
 	ctx context.Context,
@@ -253,13 +253,13 @@ func (bs *DeviceBaseTestSuite) SeedTenantRole(
 	tuples := make([]security.RelationTuple, 0, 1+len(permissions))
 
 	tuples = append(tuples, security.RelationTuple{
-		Object:   security.ObjectRef{Namespace: authz.NamespaceProfile, ID: tenancyPath},
+		Object:   security.ObjectRef{Namespace: authz.NamespaceDevice, ID: tenancyPath},
 		Relation: role,
 		Subject:  security.SubjectRef{Namespace: authz.NamespaceProfileUser, ID: profileID},
 	})
 	for _, perm := range permissions {
 		tuples = append(tuples, security.RelationTuple{
-			Object:   security.ObjectRef{Namespace: authz.NamespaceProfile, ID: tenancyPath},
+			Object:   security.ObjectRef{Namespace: authz.NamespaceDevice, ID: tenancyPath},
 			Relation: authz.GrantedRelation(perm),
 			Subject:  security.SubjectRef{Namespace: authz.NamespaceProfileUser, ID: profileID},
 		})

--- a/apps/devices/tests/testketo/keto.go
+++ b/apps/devices/tests/testketo/keto.go
@@ -48,7 +48,7 @@ class tenancy_access implements Namespace {
   }
 }
 
-class service_profile implements Namespace {
+class service_device implements Namespace {
   related: {
     owner: profile_user[]
     admin: profile_user[]
@@ -57,68 +57,11 @@ class service_profile implements Namespace {
     member: profile_user[]
     service: (profile_user | tenancy_access)[]
 
-    granted_profile_view: (profile_user | service_profile)[]
-    granted_profile_create: (profile_user | service_profile)[]
-    granted_profile_update: (profile_user | service_profile)[]
-    granted_profile_merge: (profile_user | service_profile)[]
-    granted_contact_manage: (profile_user | service_profile)[]
-    granted_roster_manage: (profile_user | service_profile)[]
-    granted_relationship_manage: (profile_user | service_profile)[]
-    granted_devices_manage: (profile_user | service_profile)[]
-    granted_devices_view: (profile_user | service_profile)[]
-    granted_geolocation_manage: (profile_user | service_profile)[]
-    granted_geolocation_view: (profile_user | service_profile)[]
-    granted_location_ingest: (profile_user | service_profile)[]
-    granted_settings_manage: (profile_user | service_profile)[]
-    granted_settings_view: (profile_user | service_profile)[]
+    granted_devices_manage: (profile_user | service_device)[]
+    granted_devices_view: (profile_user | service_device)[]
   }
 
   permits = {
-    profile_view: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.operator.includes(ctx.subject) ||
-      this.related.viewer.includes(ctx.subject) ||
-      this.related.member.includes(ctx.subject) ||
-      this.related.granted_profile_view.includes(ctx.subject),
-
-    profile_create: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_profile_create.includes(ctx.subject),
-
-    profile_update: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_profile_update.includes(ctx.subject),
-
-    profile_merge: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_profile_merge.includes(ctx.subject),
-
-    contact_manage: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_contact_manage.includes(ctx.subject),
-
-    roster_manage: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_roster_manage.includes(ctx.subject),
-
-    relationship_manage: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_relationship_manage.includes(ctx.subject),
-
     devices_manage: (ctx: Context): boolean =>
       this.related.service.includes(ctx.subject) ||
       this.related.owner.includes(ctx.subject) ||
@@ -131,39 +74,6 @@ class service_profile implements Namespace {
       this.related.viewer.includes(ctx.subject) ||
       this.related.member.includes(ctx.subject) ||
       this.related.granted_devices_view.includes(ctx.subject),
-
-    geolocation_manage: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_geolocation_manage.includes(ctx.subject),
-
-    geolocation_view: (ctx: Context): boolean =>
-      this.permits.geolocation_manage(ctx) ||
-      this.related.operator.includes(ctx.subject) ||
-      this.related.viewer.includes(ctx.subject) ||
-      this.related.member.includes(ctx.subject) ||
-      this.related.granted_geolocation_view.includes(ctx.subject),
-
-    location_ingest: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.operator.includes(ctx.subject) ||
-      this.related.granted_location_ingest.includes(ctx.subject),
-
-    settings_manage: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_settings_manage.includes(ctx.subject),
-
-    settings_view: (ctx: Context): boolean =>
-      this.permits.settings_manage(ctx) ||
-      this.related.operator.includes(ctx.subject) ||
-      this.related.viewer.includes(ctx.subject) ||
-      this.related.member.includes(ctx.subject) ||
-      this.related.granted_settings_view.includes(ctx.subject),
   }
 }
 `

--- a/apps/geolocation/service/authz/authz_test.go
+++ b/apps/geolocation/service/authz/authz_test.go
@@ -30,6 +30,6 @@ func TestTupleBuilders(t *testing.T) {
 
 	inheritance := BuildServiceInheritanceTuples("tenant/partition")
 	require.Len(t, inheritance, 1)
-	require.Equal(t, NamespaceProfile, inheritance[0].Object.Namespace)
+	require.Equal(t, NamespaceGeolocation, inheritance[0].Object.Namespace)
 	require.Equal(t, RoleService, inheritance[0].Relation)
 }

--- a/apps/geolocation/service/authz/role_mapping.go
+++ b/apps/geolocation/service/authz/role_mapping.go
@@ -3,7 +3,7 @@ package authz
 import "github.com/pitabwire/frame/security"
 
 const (
-	NamespaceProfile       = "service_profile"
+	NamespaceGeolocation   = "service_geolocation"
 	NamespaceTenancyAccess = "tenancy_access"
 	NamespaceProfileUser   = "profile_user"
 )
@@ -77,7 +77,7 @@ func BuildServiceAccessTuple(tenancyPath, profileID string) security.RelationTup
 // role directly, so explicit granted_* tuples per permission are redundant.
 func BuildServiceInheritanceTuples(tenancyPath string) []security.RelationTuple {
 	return []security.RelationTuple{{
-		Object:   security.ObjectRef{Namespace: NamespaceProfile, ID: tenancyPath},
+		Object:   security.ObjectRef{Namespace: NamespaceGeolocation, ID: tenancyPath},
 		Relation: RoleService,
 		Subject: security.SubjectRef{
 			Namespace: NamespaceTenancyAccess,

--- a/apps/geolocation/service/handlers/geolocation_handler_test.go
+++ b/apps/geolocation/service/handlers/geolocation_handler_test.go
@@ -105,7 +105,7 @@ func newHandlerStack(ctx context.Context, svc *frame.Service) *handlerStack {
 	return &handlerStack{
 		GeoServer: handlers.NewGeolocationServer(
 			svc,
-			authorizer.NewFunctionChecker(svc.SecurityManager().GetAuthorizer(ctx), "service_profile"),
+			authorizer.NewFunctionChecker(svc.SecurityManager().GetAuthorizer(ctx), "service_geolocation"),
 			ingestionBiz,
 			areaBiz,
 			routeBiz,

--- a/apps/geolocation/tests/base_testsuite.go
+++ b/apps/geolocation/tests/base_testsuite.go
@@ -183,7 +183,7 @@ func (bs *GeolocationBaseTestSuite) SeedTenantAccess(
 	bs.Require().NoError(err, "failed to seed tenant access")
 }
 
-// SeedTenantRole writes functional permission tuples in the service_profile
+// SeedTenantRole writes functional permission tuples in the service_geolocation
 // namespace for the given role.
 func (bs *GeolocationBaseTestSuite) SeedTenantRole(
 	ctx context.Context,
@@ -204,13 +204,13 @@ func (bs *GeolocationBaseTestSuite) SeedTenantRole(
 	tuples := make([]security.RelationTuple, 0, 1+len(permissions))
 
 	tuples = append(tuples, security.RelationTuple{
-		Object:   security.ObjectRef{Namespace: "service_profile", ID: tenancyPath},
+		Object:   security.ObjectRef{Namespace: "service_geolocation", ID: tenancyPath},
 		Relation: role,
 		Subject:  security.SubjectRef{Namespace: "profile_user", ID: profileID},
 	})
 	for _, perm := range permissions {
 		tuples = append(tuples, security.RelationTuple{
-			Object:   security.ObjectRef{Namespace: "service_profile", ID: tenancyPath},
+			Object:   security.ObjectRef{Namespace: "service_geolocation", ID: tenancyPath},
 			Relation: "granted_" + perm,
 			Subject:  security.SubjectRef{Namespace: "profile_user", ID: profileID},
 		})

--- a/apps/geolocation/tests/testketo/keto.go
+++ b/apps/geolocation/tests/testketo/keto.go
@@ -48,7 +48,7 @@ class tenancy_access implements Namespace {
   }
 }
 
-class service_profile implements Namespace {
+class service_geolocation implements Namespace {
   related: {
     owner: profile_user[]
     admin: profile_user[]
@@ -57,20 +57,20 @@ class service_profile implements Namespace {
     member: profile_user[]
     service: (profile_user | tenancy_access)[]
 
-    granted_profile_view: (profile_user | service_profile)[]
-    granted_profile_create: (profile_user | service_profile)[]
-    granted_profile_update: (profile_user | service_profile)[]
-    granted_profile_merge: (profile_user | service_profile)[]
-    granted_contact_manage: (profile_user | service_profile)[]
-    granted_roster_manage: (profile_user | service_profile)[]
-    granted_relationship_manage: (profile_user | service_profile)[]
-    granted_devices_manage: (profile_user | service_profile)[]
-    granted_devices_view: (profile_user | service_profile)[]
-    granted_geolocation_manage: (profile_user | service_profile)[]
-    granted_geolocation_view: (profile_user | service_profile)[]
-    granted_location_ingest: (profile_user | service_profile)[]
-    granted_settings_manage: (profile_user | service_profile)[]
-    granted_settings_view: (profile_user | service_profile)[]
+    granted_profile_view: (profile_user | service_geolocation)[]
+    granted_profile_create: (profile_user | service_geolocation)[]
+    granted_profile_update: (profile_user | service_geolocation)[]
+    granted_profile_merge: (profile_user | service_geolocation)[]
+    granted_contact_manage: (profile_user | service_geolocation)[]
+    granted_roster_manage: (profile_user | service_geolocation)[]
+    granted_relationship_manage: (profile_user | service_geolocation)[]
+    granted_devices_manage: (profile_user | service_geolocation)[]
+    granted_devices_view: (profile_user | service_geolocation)[]
+    granted_geolocation_manage: (profile_user | service_geolocation)[]
+    granted_geolocation_view: (profile_user | service_geolocation)[]
+    granted_location_ingest: (profile_user | service_geolocation)[]
+    granted_settings_manage: (profile_user | service_geolocation)[]
+    granted_settings_view: (profile_user | service_geolocation)[]
   }
 
   permits = {

--- a/apps/geolocation/tests/testketo/keto.go
+++ b/apps/geolocation/tests/testketo/keto.go
@@ -57,81 +57,12 @@ class service_geolocation implements Namespace {
     member: profile_user[]
     service: (profile_user | tenancy_access)[]
 
-    granted_profile_view: (profile_user | service_geolocation)[]
-    granted_profile_create: (profile_user | service_geolocation)[]
-    granted_profile_update: (profile_user | service_geolocation)[]
-    granted_profile_merge: (profile_user | service_geolocation)[]
-    granted_contact_manage: (profile_user | service_geolocation)[]
-    granted_roster_manage: (profile_user | service_geolocation)[]
-    granted_relationship_manage: (profile_user | service_geolocation)[]
-    granted_devices_manage: (profile_user | service_geolocation)[]
-    granted_devices_view: (profile_user | service_geolocation)[]
+    granted_location_ingest: (profile_user | service_geolocation)[]
     granted_geolocation_manage: (profile_user | service_geolocation)[]
     granted_geolocation_view: (profile_user | service_geolocation)[]
-    granted_location_ingest: (profile_user | service_geolocation)[]
-    granted_settings_manage: (profile_user | service_geolocation)[]
-    granted_settings_view: (profile_user | service_geolocation)[]
   }
 
   permits = {
-    profile_view: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.operator.includes(ctx.subject) ||
-      this.related.viewer.includes(ctx.subject) ||
-      this.related.member.includes(ctx.subject) ||
-      this.related.granted_profile_view.includes(ctx.subject),
-
-    profile_create: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_profile_create.includes(ctx.subject),
-
-    profile_update: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_profile_update.includes(ctx.subject),
-
-    profile_merge: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_profile_merge.includes(ctx.subject),
-
-    contact_manage: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_contact_manage.includes(ctx.subject),
-
-    roster_manage: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_roster_manage.includes(ctx.subject),
-
-    relationship_manage: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_relationship_manage.includes(ctx.subject),
-
-    devices_manage: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_devices_manage.includes(ctx.subject),
-
-    devices_view: (ctx: Context): boolean =>
-      this.permits.devices_manage(ctx) ||
-      this.related.operator.includes(ctx.subject) ||
-      this.related.viewer.includes(ctx.subject) ||
-      this.related.member.includes(ctx.subject) ||
-      this.related.granted_devices_view.includes(ctx.subject),
-
     geolocation_manage: (ctx: Context): boolean =>
       this.related.service.includes(ctx.subject) ||
       this.related.owner.includes(ctx.subject) ||
@@ -151,19 +82,6 @@ class service_geolocation implements Namespace {
       this.related.admin.includes(ctx.subject) ||
       this.related.operator.includes(ctx.subject) ||
       this.related.granted_location_ingest.includes(ctx.subject),
-
-    settings_manage: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_settings_manage.includes(ctx.subject),
-
-    settings_view: (ctx: Context): boolean =>
-      this.permits.settings_manage(ctx) ||
-      this.related.operator.includes(ctx.subject) ||
-      this.related.viewer.includes(ctx.subject) ||
-      this.related.member.includes(ctx.subject) ||
-      this.related.granted_settings_view.includes(ctx.subject),
   }
 }
 `

--- a/apps/settings/service/authz/role_mapping.go
+++ b/apps/settings/service/authz/role_mapping.go
@@ -3,7 +3,7 @@ package authz
 import "github.com/pitabwire/frame/security"
 
 const (
-	NamespaceProfile       = "service_profile"
+	NamespaceSetting       = "service_setting"
 	NamespaceTenancyAccess = "tenancy_access"
 	NamespaceProfileUser   = "profile_user"
 )
@@ -76,7 +76,7 @@ func BuildServiceAccessTuple(tenancyPath, profileID string) security.RelationTup
 // role directly, so explicit granted_* tuples per permission are redundant.
 func BuildServiceInheritanceTuples(tenancyPath string) []security.RelationTuple {
 	return []security.RelationTuple{{
-		Object:   security.ObjectRef{Namespace: NamespaceProfile, ID: tenancyPath},
+		Object:   security.ObjectRef{Namespace: NamespaceSetting, ID: tenancyPath},
 		Relation: RoleService,
 		Subject: security.SubjectRef{
 			Namespace: NamespaceTenancyAccess,

--- a/apps/settings/tests/base_testsuite.go
+++ b/apps/settings/tests/base_testsuite.go
@@ -153,7 +153,7 @@ func (bs *SettingsBaseTestSuite) SeedTenantAccess(
 	bs.Require().NoError(err, "failed to seed tenant access")
 }
 
-// SeedTenantRole writes functional permission tuples in the service_profile
+// SeedTenantRole writes functional permission tuples in the service_setting
 // namespace for the given role.
 func (bs *SettingsBaseTestSuite) SeedTenantRole(
 	ctx context.Context,
@@ -167,13 +167,13 @@ func (bs *SettingsBaseTestSuite) SeedTenantRole(
 	tuples := make([]security.RelationTuple, 0, 1+len(permissions))
 
 	tuples = append(tuples, security.RelationTuple{
-		Object:   security.ObjectRef{Namespace: authz.NamespaceProfile, ID: tenancyPath},
+		Object:   security.ObjectRef{Namespace: authz.NamespaceSetting, ID: tenancyPath},
 		Relation: role,
 		Subject:  security.SubjectRef{Namespace: authz.NamespaceProfileUser, ID: profileID},
 	})
 	for _, perm := range permissions {
 		tuples = append(tuples, security.RelationTuple{
-			Object:   security.ObjectRef{Namespace: authz.NamespaceProfile, ID: tenancyPath},
+			Object:   security.ObjectRef{Namespace: authz.NamespaceSetting, ID: tenancyPath},
 			Relation: authz.GrantedRelation(perm),
 			Subject:  security.SubjectRef{Namespace: authz.NamespaceProfileUser, ID: profileID},
 		})

--- a/apps/settings/tests/testketo/keto.go
+++ b/apps/settings/tests/testketo/keto.go
@@ -48,7 +48,7 @@ class tenancy_access implements Namespace {
   }
 }
 
-class service_profile implements Namespace {
+class service_setting implements Namespace {
   related: {
     owner: profile_user[]
     admin: profile_user[]
@@ -57,101 +57,11 @@ class service_profile implements Namespace {
     member: profile_user[]
     service: (profile_user | tenancy_access)[]
 
-    granted_profile_view: (profile_user | service_profile)[]
-    granted_profile_create: (profile_user | service_profile)[]
-    granted_profile_update: (profile_user | service_profile)[]
-    granted_profile_merge: (profile_user | service_profile)[]
-    granted_contact_manage: (profile_user | service_profile)[]
-    granted_roster_manage: (profile_user | service_profile)[]
-    granted_relationship_manage: (profile_user | service_profile)[]
-    granted_devices_manage: (profile_user | service_profile)[]
-    granted_devices_view: (profile_user | service_profile)[]
-    granted_geolocation_manage: (profile_user | service_profile)[]
-    granted_geolocation_view: (profile_user | service_profile)[]
-    granted_location_ingest: (profile_user | service_profile)[]
-    granted_settings_manage: (profile_user | service_profile)[]
-    granted_settings_view: (profile_user | service_profile)[]
+    granted_settings_manage: (profile_user | service_setting)[]
+    granted_settings_view: (profile_user | service_setting)[]
   }
 
   permits = {
-    profile_view: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.operator.includes(ctx.subject) ||
-      this.related.viewer.includes(ctx.subject) ||
-      this.related.member.includes(ctx.subject) ||
-      this.related.granted_profile_view.includes(ctx.subject),
-
-    profile_create: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_profile_create.includes(ctx.subject),
-
-    profile_update: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_profile_update.includes(ctx.subject),
-
-    profile_merge: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_profile_merge.includes(ctx.subject),
-
-    contact_manage: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_contact_manage.includes(ctx.subject),
-
-    roster_manage: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_roster_manage.includes(ctx.subject),
-
-    relationship_manage: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_relationship_manage.includes(ctx.subject),
-
-    devices_manage: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_devices_manage.includes(ctx.subject),
-
-    devices_view: (ctx: Context): boolean =>
-      this.permits.devices_manage(ctx) ||
-      this.related.operator.includes(ctx.subject) ||
-      this.related.viewer.includes(ctx.subject) ||
-      this.related.member.includes(ctx.subject) ||
-      this.related.granted_devices_view.includes(ctx.subject),
-
-    geolocation_manage: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.granted_geolocation_manage.includes(ctx.subject),
-
-    geolocation_view: (ctx: Context): boolean =>
-      this.permits.geolocation_manage(ctx) ||
-      this.related.operator.includes(ctx.subject) ||
-      this.related.viewer.includes(ctx.subject) ||
-      this.related.member.includes(ctx.subject) ||
-      this.related.granted_geolocation_view.includes(ctx.subject),
-
-    location_ingest: (ctx: Context): boolean =>
-      this.related.service.includes(ctx.subject) ||
-      this.related.owner.includes(ctx.subject) ||
-      this.related.admin.includes(ctx.subject) ||
-      this.related.operator.includes(ctx.subject) ||
-      this.related.granted_location_ingest.includes(ctx.subject),
-
     settings_manage: (ctx: Context): boolean =>
       this.related.service.includes(ctx.subject) ||
       this.related.owner.includes(ctx.subject) ||

--- a/geolocation/v1/geolocation.pb.go
+++ b/geolocation/v1/geolocation.pb.go
@@ -3314,7 +3314,7 @@ const file_geolocation_v1_geolocation_proto_rawDesc = "" +
 	"\x17RouteDeviationEventType\x12*\n" +
 	"&ROUTE_DEVIATION_EVENT_TYPE_UNSPECIFIED\x10\x00\x12'\n" +
 	"#ROUTE_DEVIATION_EVENT_TYPE_DEVIATED\x10\x01\x12,\n" +
-	"(ROUTE_DEVIATION_EVENT_TYPE_BACK_ON_ROUTE\x10\x022\xef\x14\n" +
+	"(ROUTE_DEVIATION_EVENT_TYPE_BACK_ON_ROUTE\x10\x022\xf3\x14\n" +
 	"\x12GeolocationService\x12y\n" +
 	"\x0fIngestLocations\x12&.geolocation.v1.IngestLocationsRequest\x1a'.geolocation.v1.IngestLocationsResponse\"\x15\x82\xb5\x18\x11\n" +
 	"\x0flocation_ingest\x12f\n" +
@@ -3361,8 +3361,8 @@ const file_geolocation_v1_geolocation_proto_rawDesc = "" +
 	"\x11GetNearbySubjects\x12(.geolocation.v1.GetNearbySubjectsRequest\x1a).geolocation.v1.GetNearbySubjectsResponse\"\x11\x82\xb5\x18\r\n" +
 	"\vnearby_view\x12r\n" +
 	"\x0eGetNearbyAreas\x12%.geolocation.v1.GetNearbyAreasRequest\x1a&.geolocation.v1.GetNearbyAreasResponse\"\x11\x82\xb5\x18\r\n" +
-	"\vnearby_view\x1a\xbf\x04\x82\xb5\x18\xba\x04\n" +
-	"\x0fservice_profile\x12\x0flocation_ingest\x12\tarea_view\x12\varea_manage\x12\n" +
+	"\vnearby_view\x1a\xc3\x04\x82\xb5\x18\xbe\x04\n" +
+	"\x13service_geolocation\x12\x0flocation_ingest\x12\tarea_view\x12\varea_manage\x12\n" +
 	"route_view\x12\froute_manage\x12\n" +
 	"track_view\x12\vnearby_view\x1a^\b\x01\x12\x0flocation_ingest\x12\tarea_view\x12\varea_manage\x12\n" +
 	"route_view\x12\froute_manage\x12\n" +

--- a/proto/geolocation/geolocation/v1/geolocation.proto
+++ b/proto/geolocation/geolocation/v1/geolocation.proto
@@ -324,7 +324,7 @@ message GetNearbyAreasResponse {
 
 service GeolocationService {
   option (common.v1.service_permissions) = {
-    namespace: "service_profile"
+    namespace: "service_geolocation"
     permissions: [
       "location_ingest",
       "area_view",


### PR DESCRIPTION
## Problem

Contact-based login was broken platform-wide (verified on `opportunities.stawi.org`): the login page accepted an email/phone but never sent a verification code, looping back to the email step.

**Root cause:** `GeolocationService` declared `service_permissions.namespace = "service_profile"` — the namespace owned by `ProfileService`. At startup both apps POST their permission manifests to the tenancy service keyed on namespace (last-writer-wins `Update`), so geolocation's manifest (`location_ingest`, `area_view`, …) overwrote profile's (`profile_view`, `contact_manage`, …) in `tenancy.service_namespaces`.

The tenancy OPL generator (`apps/tenancy/service/opl/generate.go`) then emitted a `service_profile` Keto class containing **geolocation** permits and **missing `profile_view`/`contact_manage`**. Every profile authz check failed:

```
GetByContact → FunctionChecker check (service_profile / profile_view)
→ Keto 400 "relation profile_view does not exist" (InvalidArgument)
→ login_step_1_post.go:89 "profile lookup failed" → redirect to email step, no code
```

Commit `bd8397c` renamed the geolocation **OPL class** to `service_geolocation` but left the **proto annotation** — the source of truth for both manifest registration and `FunctionChecker` enforcement — at `service_profile`. This completes that rename.

## Fix

Change the `GeolocationService` `service_permissions.namespace` to `service_geolocation` and regenerate. Geolocation now registers its own namespace and stops clobbering `service_profile`.

## Verification

- Production was hot-fixed already by restarting `service-profile` (re-registering the correct `service_profile` manifest), reconciling the `identity-authorization` Flux kustomization to regenerate `keto-namespace-combined`, after which Keto hot-reloaded. `profile_view` and `contact_manage` checks now return `allowed:true`.
- Full login flow re-tested end-to-end on `opportunities.stawi.org`: email → verification code → consent → authenticated. ✅
- `buf lint` clean; `go build ./apps/geolocation/... ./apps/default/...` passes.

## Note / follow-up

Any existing geolocation relation tuples written under `service_profile` would need migration to `service_geolocation`, but geolocation is not currently a standing deployment so this is expected to be a no-op. The durable fix here prevents the next geolocation registration from re-clobbering `service_profile`.