### PR TITLE
chore(deps): frame v1.98.0, OpenTelemetry v1.44, gocloud v0.46

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/google/gnostic v0.7.1
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/mssola/user_agent v0.6.0
-	github.com/pitabwire/frame v1.97.8
+	github.com/pitabwire/frame v1.98.0
 	github.com/pitabwire/util v0.9.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame v1.97.8 h1:aW4XisUvktK7NAy21JyARgRx2ClNTbDVjXpvGUZsK1s=
-github.com/pitabwire/frame v1.97.8/go.mod h1:x8blcfNCpC7kBjWBmfr4qgXH1sUOwbZ971vX7AmEk9c=
+github.com/pitabwire/frame v1.98.0 h1:c/kbZxvM7IUekl/nzFe9F1jrEzSGp/Y9N3qEInpKv+4=
+github.com/pitabwire/frame v1.98.0/go.mod h1:SFbceOJiJdvM9iTwf1CkCWlUQylvp7fPpB1GDP4Pz20=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.0 h1:fnlTAuWKqAjc6GalO+a7hMeo6g3fAv5yjmaP237ChP4=


### PR DESCRIPTION
Adopts **frame v1.98.0** (telemetry migrated to OTel v1.44 / semconv v1.41) and aligns the OpenTelemetry stack to **v1.44** + **gocloud v0.46**.

Fixes the `resource.Merge` *conflicting Schema URL (1.41.0 vs 1.40.0)* failure that broke telemetry init and every container test's `SetupSuite` once OTel v1.44 entered the graph. Verified: `go build ./...` passes and `resource.Merge(resource.Default(), frameResource)` now unifies at schema 1.41.0.

Part of the platform-wide OTel v1.44 / frame v1.98.0 rollout.