### PR TITLE
fix(geolocation): bump BSR proto deps so binary registers service_geolocation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	buf.build/gen/go/antinvestor/common/protocolbuffers/go v1.36.11-20260509050709-3f270876dbf3.1
 	buf.build/gen/go/antinvestor/device/connectrpc/go v1.20.0-20260511135702-7f6c3cf72171.1
 	buf.build/gen/go/antinvestor/device/protocolbuffers/go v1.36.11-20260511135702-7f6c3cf72171.1
-	buf.build/gen/go/antinvestor/geolocation/connectrpc/go v1.20.0-20260511135702-c644c74b7b9a.1
-	buf.build/gen/go/antinvestor/geolocation/protocolbuffers/go v1.36.11-20260511135702-c644c74b7b9a.1
+	buf.build/gen/go/antinvestor/geolocation/connectrpc/go v1.20.0-20260608193017-9eca582ae046.1
+	buf.build/gen/go/antinvestor/geolocation/protocolbuffers/go v1.36.11-20260608193017-9eca582ae046.1
 	buf.build/gen/go/antinvestor/notification/connectrpc/go v1.20.0-20260511135618-9b1ea0d95bd7.1
 	buf.build/gen/go/antinvestor/notification/protocolbuffers/go v1.36.11-20260511135618-9b1ea0d95bd7.1
 	buf.build/gen/go/antinvestor/profile/connectrpc/go v1.20.0-20260511135702-c54f3e4a0a91.1

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,10 @@ buf.build/gen/go/antinvestor/device/connectrpc/go v1.20.0-20260511135702-7f6c3cf
 buf.build/gen/go/antinvestor/device/connectrpc/go v1.20.0-20260511135702-7f6c3cf72171.1/go.mod h1:QEX26/qcndV5uD/zB8O687d8ktXN3iLq3iUzEd3JOlc=
 buf.build/gen/go/antinvestor/device/protocolbuffers/go v1.36.11-20260511135702-7f6c3cf72171.1 h1:0RBrl+4F6prI6s0v+vkUMCDK/s7lbIJOjrjn/dLM5kQ=
 buf.build/gen/go/antinvestor/device/protocolbuffers/go v1.36.11-20260511135702-7f6c3cf72171.1/go.mod h1:VePA43rcicCRVOYea7PRbLKQIVfWr26TmTApoVcnKl0=
-buf.build/gen/go/antinvestor/geolocation/connectrpc/go v1.20.0-20260511135702-c644c74b7b9a.1 h1:dx51ijFxJkxqoN34WZ+jnoTI7q08zYJiJDxr6+KL8Jg=
-buf.build/gen/go/antinvestor/geolocation/connectrpc/go v1.20.0-20260511135702-c644c74b7b9a.1/go.mod h1:Y7VoQv7fk2LIkjz0QFnKaCaRaptzgEhPpPhEkc+YgK0=
-buf.build/gen/go/antinvestor/geolocation/protocolbuffers/go v1.36.11-20260511135702-c644c74b7b9a.1 h1:zJZr/YKiPqi4ZhSg0UUpRK5fWQGk7ymTLl9h5hKBAGY=
-buf.build/gen/go/antinvestor/geolocation/protocolbuffers/go v1.36.11-20260511135702-c644c74b7b9a.1/go.mod h1:zhgU14zHzrcRhdVdZJ/RLgZMLe6Xrb6VIHgRM34WrlA=
+buf.build/gen/go/antinvestor/geolocation/connectrpc/go v1.20.0-20260608193017-9eca582ae046.1 h1:GjSLV98nl4gRvNqEmm3La/sfEnHOGmb32RkXz2srIZU=
+buf.build/gen/go/antinvestor/geolocation/connectrpc/go v1.20.0-20260608193017-9eca582ae046.1/go.mod h1:fXvT8yHZ0ScYRkkDQEM4SDJWXeIu2U4Y7OVoI+GYnrM=
+buf.build/gen/go/antinvestor/geolocation/protocolbuffers/go v1.36.11-20260608193017-9eca582ae046.1 h1:dV/WTxNdJRbA+fmtMfIjMq2iPHjI4XOnCZJDzSEp/Io=
+buf.build/gen/go/antinvestor/geolocation/protocolbuffers/go v1.36.11-20260608193017-9eca582ae046.1/go.mod h1:zhgU14zHzrcRhdVdZJ/RLgZMLe6Xrb6VIHgRM34WrlA=
 buf.build/gen/go/antinvestor/notification/connectrpc/go v1.20.0-20260511135618-9b1ea0d95bd7.1 h1:qHTdnNNfkdq8NacyArvXMk4lNi2SqXCKa3r6dbGT/Fw=
 buf.build/gen/go/antinvestor/notification/connectrpc/go v1.20.0-20260511135618-9b1ea0d95bd7.1/go.mod h1:zkskJD98ZrHoqOV0XK/GqrGlwULJVNVOHrCsOHeXK4A=
 buf.build/gen/go/antinvestor/notification/protocolbuffers/go v1.36.11-20260511135618-9b1ea0d95bd7.1 h1:NcWRgOtL2A09cThVXGGwRXJMFaHJmOLVF8yJHE+BpiI=


### PR DESCRIPTION
## Problem

`service-geolocation` had to be scaled to 0 in the cluster because, whenever it runs, it breaks contact-based login **platform-wide**.

## Root cause

The geolocation app resolves its `GeolocationService` descriptor from the **BSR** module `buf.build/gen/go/antinvestor/geolocation/*` — not the local generated code. Commit 2ace9ad (#573) fixed the proto annotation (`service_permissions.namespace: service_profile → service_geolocation`) and pushed it to BSR (commit `20260608193017`), **but `go.mod` still pinned the prior BSR commit `20260511135702`**, whose descriptor encodes `namespace=service_profile`.

So the built binary kept registering its permission manifest under `service_profile`, racing `ProfileService` on the same registry key (last-writer-wins) and overwriting the profile permits (`profile_view`, `contact_manage`, …) with geolocation permits. Keto's `service_profile` namespace then lacked profile permits, so every profile authz check (`GetByContact → profile_view`) failed with `InvalidArgument` → login accepted the contact but never issued a verification code.

## Fix

Bump both geolocation BSR deps to `20260608193017-9eca582ae046` so the compiled descriptor uses `service_geolocation`.

**Verified:** rebuilt binary embeds `service_geolocation` (×6) and **zero** `service_profile`.

## After merge
Rebuild/republish the geolocation image from this commit, redeploy, and scale `service-geolocation` back to 1 — it will register `service_geolocation` and no longer clobber `service_profile`.