### PR TITLE
test: exercise Postgres RLS in suites and add cross-tenant isolation tests

### DIFF
--- a/apps/default/service/repository/tenant_isolation_test.go
+++ b/apps/default/service/repository/tenant_isolation_test.go
@@ -1,0 +1,98 @@
+package repository_test
+
+import (
+	"testing"
+
+	"github.com/pitabwire/frame/datastore"
+	"github.com/pitabwire/frame/frametests/definition"
+	"github.com/pitabwire/util"
+	"github.com/stretchr/testify/require"
+
+	"github.com/antinvestor/service-profile/apps/default/service/models"
+	"github.com/antinvestor/service-profile/apps/default/service/repository"
+)
+
+// TestRosterTenantIsolation verifies Postgres RLS actually hides
+// tenant-scoped rows across tenants. Rosters are tenant-private (the
+// repository does NOT use security.SkipTenancyChecksOnClaims), unlike
+// profiles/contacts which are deliberately globally readable.
+func (rts *RepositoryTestSuite) TestRosterTenantIsolation() {
+	t := rts.T()
+
+	rts.WithTestDependancies(t, func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, svc := rts.CreateService(t, dep)
+
+		dbPool := svc.DatastoreManager().GetPool(ctx, datastore.DefaultPoolName)
+		workMan := svc.WorkManager()
+		contactRepo := repository.NewContactRepository(ctx, dbPool, workMan)
+		rosterRepo := repository.NewRosterRepository(ctx, dbPool, workMan)
+
+		ctxA := rts.WithAuthClaims(ctx, "tenant-a", "partition-a", util.IDString())
+		ctxB := rts.WithAuthClaims(ctx, "tenant-b", "partition-b", util.IDString())
+
+		profileID := util.IDString()
+
+		contact := &models.Contact{
+			LookUpToken:     []byte("isolation-token-" + util.IDString()),
+			EncryptedDetail: []byte("encrypted-detail"),
+			EncryptionKeyID: "test-key-id",
+			ContactType:     "EMAIL",
+			ProfileID:       profileID,
+		}
+		contact.GenID(ctxA)
+		require.NoError(t, contactRepo.Create(ctxA, contact))
+
+		roster := &models.Roster{
+			ProfileID: profileID,
+			ContactID: contact.GetID(),
+			Name:      "isolation-roster",
+		}
+		roster.GenID(ctxA)
+		require.NoError(t, rosterRepo.Create(ctxA, roster))
+
+		// Owning tenant can read its roster entry back.
+		got, err := rosterRepo.GetByID(ctxA, roster.GetID())
+		require.NoError(t, err)
+		require.Equal(t, roster.GetID(), got.GetID())
+
+		// Another tenant must not be able to read it.
+		_, err = rosterRepo.GetByID(ctxB, roster.GetID())
+		require.Error(t, err, "tenant B must not read tenant A's roster entry")
+
+		entries, err := rosterRepo.GetByContactIDsAndProfileID(ctxB, []string{contact.GetID()}, profileID)
+		require.NoError(t, err)
+		require.Empty(t, entries, "tenant B must not list tenant A's roster entries")
+	})
+}
+
+// TestVerificationTenantIsolation verifies contact verifications are
+// tenant-private even though the contacts they belong to are globally
+// readable by design.
+func (rts *RepositoryTestSuite) TestVerificationTenantIsolation() {
+	t := rts.T()
+
+	rts.WithTestDependancies(t, func(t *testing.T, dep *definition.DependencyOption) {
+		ctx, svc := rts.CreateService(t, dep)
+		_, _, verificationRepo := rts.getRepositories(ctx, svc)
+
+		ctxA := rts.WithAuthClaims(ctx, "tenant-a", "partition-a", util.IDString())
+		ctxB := rts.WithAuthClaims(ctx, "tenant-b", "partition-b", util.IDString())
+
+		verification := &models.Verification{
+			ProfileID: util.IDString(),
+			ContactID: util.IDString(),
+			Code:      "123456",
+		}
+		verification.GenID(ctxA)
+		require.NoError(t, verificationRepo.Create(ctxA, verification))
+
+		// Owning tenant can read the verification back.
+		got, err := verificationRepo.GetByID(ctxA, verification.GetID())
+		require.NoError(t, err)
+		require.Equal(t, verification.GetID(), got.GetID())
+
+		// Another tenant must not see it.
+		_, err = verificationRepo.GetByID(ctxB, verification.GetID())
+		require.Error(t, err, "tenant B must not read tenant A's verification")
+	})
+}

--- a/apps/default/tests/base_testsuite.go
+++ b/apps/default/tests/base_testsuite.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pitabwire/frame/frametests"
 	"github.com/pitabwire/frame/frametests/definition"
 	"github.com/pitabwire/frame/frametests/deps/testpostgres"
+	"github.com/pitabwire/frame/frametests/rlstest"
 	"github.com/pitabwire/frame/security"
 	"github.com/pitabwire/frame/security/authorizer"
 	"github.com/pitabwire/util"
@@ -30,6 +31,7 @@ import (
 	"github.com/antinvestor/service-profile/apps/default/service/events"
 	"github.com/antinvestor/service-profile/apps/default/service/repository"
 	"github.com/antinvestor/service-profile/apps/default/tests/testketo"
+	"github.com/antinvestor/service-profile/internal/rlsadmin"
 )
 
 const PostgresqlDBImage = "postgres:latest"
@@ -122,10 +124,19 @@ func (bs *ProfileBaseTestSuite) CreateService(
 	cfg.AuthorizationServiceReadURI = bs.ketoReadURI
 	cfg.AuthorizationServiceWriteURI = bs.ketoWriteURI
 
+	// The postgres testcontainer user is a superuser which bypasses RLS,
+	// so application queries are dropped to an unprivileged role to
+	// actually exercise the tenancy-isolation policies installed during
+	// migration.
+	require.NoError(t, rlstest.CreateRole(ctx, testDS.String()))
+	rlsProv := rlstest.New()
+
 	ctx, svc := frame.NewServiceWithContext(t.Context(), frame.WithName("profile tests"),
 		frame.WithConfig(&cfg),
+		frame.WithTenancyProvider(rlsProv),
 		frame.WithDatastore(pool.WithTraceConfig(&cfg)),
 		frametests.WithNoopDriver())
+	t.Cleanup(func() { svc.Stop(ctx) })
 
 	// Wire real Keto authoriser via SecurityManager
 	sm := svc.SecurityManager()
@@ -160,6 +171,10 @@ func (bs *ProfileBaseTestSuite) CreateService(
 
 	err = repository.Migrate(ctx, svc.DatastoreManager(), "../../migrations/0001")
 	require.NoError(t, err)
+
+	require.NoError(t, rlstest.GrantAll(ctx, testDS.String()))
+	require.NoError(t, rlsadmin.GrantOwnership(ctx, testDS.String()))
+	rlsProv.Enable()
 
 	err = svc.Run(ctx, "")
 	require.NoError(t, err)

--- a/apps/devices/tests/base_testsuite.go
+++ b/apps/devices/tests/base_testsuite.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pitabwire/frame/frametests"
 	"github.com/pitabwire/frame/frametests/definition"
 	"github.com/pitabwire/frame/frametests/deps/testpostgres"
+	"github.com/pitabwire/frame/frametests/rlstest"
 	"github.com/pitabwire/frame/security"
 	"github.com/pitabwire/frame/security/authorizer"
 	"github.com/pitabwire/util"
@@ -24,6 +25,7 @@ import (
 	devQueue "github.com/antinvestor/service-profile/apps/devices/service/queue"
 	"github.com/antinvestor/service-profile/apps/devices/service/repository"
 	"github.com/antinvestor/service-profile/apps/devices/tests/testketo"
+	"github.com/antinvestor/service-profile/internal/rlsadmin"
 )
 
 const (
@@ -171,8 +173,15 @@ func (bs *DeviceBaseTestSuite) CreateService(
 	cfg.AuthorizationServiceReadURI = bs.ketoReadURI
 	cfg.AuthorizationServiceWriteURI = bs.ketoWriteURI
 
+	// Drop application queries to an unprivileged role so Postgres RLS
+	// is actually enforced (the testcontainer user is a superuser which
+	// bypasses FORCE ROW LEVEL SECURITY).
+	require.NoError(t, rlstest.CreateRole(ctx, testDS.String()))
+	rlsProv := rlstest.New()
+
 	ctx, svc := frame.NewServiceWithContext(ctx, frame.WithName("device tests"),
 		frame.WithConfig(&cfg),
+		frame.WithTenancyProvider(rlsProv),
 		frame.WithDatastore(),
 		frame.WithCacheManager(),
 		frame.WithInMemoryCache(aconfig.CacheNameDevices),
@@ -180,6 +189,7 @@ func (bs *DeviceBaseTestSuite) CreateService(
 		frame.WithInMemoryCache(aconfig.CacheNameGeoIP),
 		frame.WithInMemoryCache(aconfig.CacheNameRate),
 		frametests.WithNoopDriver())
+	t.Cleanup(func() { svc.Stop(ctx) })
 
 	// Wire real Keto authoriser via SecurityManager
 	sm := svc.SecurityManager()
@@ -202,6 +212,10 @@ func (bs *DeviceBaseTestSuite) CreateService(
 
 	err = repository.Migrate(ctx, svc.DatastoreManager(), "../../migrations/0001")
 	require.NoError(t, err)
+
+	require.NoError(t, rlstest.GrantAll(ctx, testDS.String()))
+	require.NoError(t, rlsadmin.GrantOwnership(ctx, testDS.String()))
+	rlsProv.Enable()
 
 	err = svc.Run(ctx, "")
 	require.NoError(t, err)

--- a/apps/geolocation/tests/base_testsuite.go
+++ b/apps/geolocation/tests/base_testsuite.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pitabwire/frame/frametests"
 	"github.com/pitabwire/frame/frametests/definition"
 	"github.com/pitabwire/frame/frametests/deps/testpostgres"
+	"github.com/pitabwire/frame/frametests/rlstest"
 	"github.com/pitabwire/frame/security"
 	"github.com/pitabwire/util"
 	"github.com/stretchr/testify/require"
@@ -20,6 +21,7 @@ import (
 	aconfig "github.com/antinvestor/service-profile/apps/geolocation/config"
 	"github.com/antinvestor/service-profile/apps/geolocation/service/models"
 	"github.com/antinvestor/service-profile/apps/geolocation/tests/testketo"
+	"github.com/antinvestor/service-profile/internal/rlsadmin"
 )
 
 const (
@@ -105,10 +107,18 @@ func (bs *GeolocationBaseTestSuite) CreateService(
 	cfg.AuthorizationServiceReadURI = bs.ketoReadURI
 	cfg.AuthorizationServiceWriteURI = bs.ketoWriteURI
 
+	// Drop application queries to an unprivileged role so Postgres RLS
+	// is actually enforced (the testcontainer user is a superuser which
+	// bypasses FORCE ROW LEVEL SECURITY).
+	require.NoError(t, rlstest.CreateRole(ctx, testDS.String()))
+	rlsProv := rlstest.New()
+
 	ctx, svc := frame.NewServiceWithContext(t.Context(), frame.WithName("geolocation tests"),
 		frame.WithConfig(&cfg),
+		frame.WithTenancyProvider(rlsProv),
 		frame.WithDatastore(),
 		frametests.WithNoopDriver())
+	t.Cleanup(func() { svc.Stop(ctx) })
 
 	require.NoError(t, enablePostGIS(ctx, testDS.String()))
 
@@ -128,6 +138,10 @@ func (bs *GeolocationBaseTestSuite) CreateService(
 		&models.RouteDeviationState{},
 	)
 	require.NoError(t, err)
+
+	require.NoError(t, rlstest.GrantAll(ctx, testDS.String()))
+	require.NoError(t, rlsadmin.GrantOwnership(ctx, testDS.String()))
+	rlsProv.Enable()
 
 	err = svc.Run(ctx, "")
 	require.NoError(t, err)

--- a/apps/settings/service/business/settings_isolation_test.go
+++ b/apps/settings/service/business/settings_isolation_test.go
@@ -1,0 +1,65 @@
+package business_test
+
+import (
+	"testing"
+
+	"github.com/pitabwire/frame/datastore"
+	"github.com/pitabwire/frame/frametests/definition"
+	"github.com/pitabwire/util"
+	"github.com/stretchr/testify/require"
+
+	"github.com/antinvestor/service-profile/apps/settings/service/models"
+	"github.com/antinvestor/service-profile/apps/settings/service/repository"
+)
+
+// TestSettingValTenantIsolation verifies Postgres RLS hides one
+// tenant's setting values from another tenant. The suite drops
+// application queries to an unprivileged role, so the tenancy
+// policies installed during migration are actually enforced.
+func (ts *SettingsTestSuite) TestSettingValTenantIsolation() {
+	ts.WithTestDependancies(ts.T(), func(t *testing.T, depOpt *definition.DependencyOption) {
+		ctx, svc := ts.CreateService(t, depOpt)
+
+		workMan := svc.WorkManager()
+		dbPool := svc.DatastoreManager().GetPool(ctx, datastore.DefaultPoolName)
+		refRepo := repository.NewReferenceRepository(ctx, dbPool, workMan)
+		valRepo := repository.NewSettingValRepository(ctx, dbPool, workMan)
+
+		ctxA := ts.WithAuthClaims(ctx, "tenant-a", "partition-a", util.IDString())
+		ctxB := ts.WithAuthClaims(ctx, "tenant-b", "partition-b", util.IDString())
+
+		ref := &models.SettingRef{
+			Name:     "isolation-setting",
+			Object:   "profile",
+			ObjectID: util.IDString(),
+			Language: "en",
+			Module:   "test",
+		}
+		ref.GenID(ctxA)
+		require.NoError(t, refRepo.Create(ctxA, ref))
+
+		val := &models.SettingVal{
+			Ref:    ref.GetID(),
+			Detail: "tenant-a-secret-value",
+		}
+		val.GenID(ctxA)
+		require.NoError(t, valRepo.Create(ctxA, val))
+
+		// Owning tenant reads its value back.
+		got, err := valRepo.GetByID(ctxA, val.GetID())
+		require.NoError(t, err)
+		require.Equal(t, "tenant-a-secret-value", got.Detail)
+
+		// Another tenant must not be able to read it.
+		_, err = valRepo.GetByID(ctxB, val.GetID())
+		require.Error(t, err, "tenant B must not read tenant A's setting value")
+
+		vals, err := valRepo.GetByRef(ctxB, ref.GetID())
+		require.NoError(t, err)
+		require.Empty(t, vals, "tenant B must not list tenant A's setting values")
+
+		// The reference itself is tenant-scoped too.
+		_, err = refRepo.GetByID(ctxB, ref.GetID())
+		require.Error(t, err, "tenant B must not read tenant A's setting reference")
+	})
+}

--- a/apps/settings/service/repository/migrate.go
+++ b/apps/settings/service/repository/migrate.go
@@ -11,7 +11,10 @@ import (
 func Migrate(ctx context.Context, dbManager datastore.Manager, migrationPath string) error {
 	dbPool := dbManager.GetPool(ctx, datastore.DefaultMigrationPoolName)
 
+	// Models MUST be registered as pointers: tenancy.Tenanted is only
+	// satisfied by *data.BaseModel receivers, so value-registered models
+	// are silently skipped during RLS policy installation.
 	return dbManager.Migrate(ctx, dbPool, migrationPath,
-		models.SettingRef{}, models.SettingVal{}, models.SettingAudit{},
+		&models.SettingRef{}, &models.SettingVal{}, &models.SettingAudit{},
 	)
 }

--- a/apps/settings/tests/base_testsuite.go
+++ b/apps/settings/tests/base_testsuite.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pitabwire/frame/frametests"
 	"github.com/pitabwire/frame/frametests/definition"
 	"github.com/pitabwire/frame/frametests/deps/testpostgres"
+	"github.com/pitabwire/frame/frametests/rlstest"
 	"github.com/pitabwire/frame/security"
 	"github.com/pitabwire/util"
 	"github.com/stretchr/testify/require"
@@ -21,6 +22,7 @@ import (
 	"github.com/antinvestor/service-profile/apps/settings/service/events"
 	"github.com/antinvestor/service-profile/apps/settings/service/repository"
 	"github.com/antinvestor/service-profile/apps/settings/tests/testketo"
+	"github.com/antinvestor/service-profile/internal/rlsadmin"
 )
 
 const (
@@ -101,10 +103,18 @@ func (bs *SettingsBaseTestSuite) CreateService(
 	cfg.AuthorizationServiceReadURI = bs.ketoReadURI
 	cfg.AuthorizationServiceWriteURI = bs.ketoWriteURI
 
+	// Drop application queries to an unprivileged role so Postgres RLS
+	// is actually enforced (the testcontainer user is a superuser which
+	// bypasses FORCE ROW LEVEL SECURITY).
+	require.NoError(t, rlstest.CreateRole(ctx, testDS.String()))
+	rlsProv := rlstest.New()
+
 	ctx, svc := frame.NewServiceWithContext(t.Context(), frame.WithName("settings tests"),
 		frame.WithConfig(&cfg),
+		frame.WithTenancyProvider(rlsProv),
 		frame.WithDatastore(),
 		frametests.WithNoopDriver())
+	t.Cleanup(func() { svc.Stop(ctx) })
 
 	dbPool := svc.DatastoreManager().GetPool(ctx, datastore.DefaultPoolName)
 
@@ -116,6 +126,10 @@ func (bs *SettingsBaseTestSuite) CreateService(
 
 	err = repository.Migrate(ctx, svc.DatastoreManager(), "../../migrations/0001")
 	require.NoError(t, err)
+
+	require.NoError(t, rlstest.GrantAll(ctx, testDS.String()))
+	require.NoError(t, rlsadmin.GrantOwnership(ctx, testDS.String()))
+	rlsProv.Enable()
 
 	err = svc.Run(ctx, "")
 	require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/google/gnostic v0.7.1
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/mssola/user_agent v0.6.0
-	github.com/pitabwire/frame v1.98.1
+	github.com/pitabwire/frame v1.98.2
 	github.com/pitabwire/util v0.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame v1.98.1 h1:MdHUk9ux0XTgrerATnpQ5nC3iT0v7MXFEbChQ91/FEc=
-github.com/pitabwire/frame v1.98.1/go.mod h1:k6TV0rPXAgR8hG5CH3vjqepmitIiw5EvHVM7dfR1xV8=
+github.com/pitabwire/frame v1.98.2 h1:Kv/9w4+P/2En9hGBrXawNPOk0DMwek8HUg0A21WMnu8=
+github.com/pitabwire/frame v1.98.2/go.mod h1:k6TV0rPXAgR8hG5CH3vjqepmitIiw5EvHVM7dfR1xV8=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=

--- a/internal/rlsadmin/rlsadmin.go
+++ b/internal/rlsadmin/rlsadmin.go
@@ -1,0 +1,81 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rlsadmin complements frame's frametests/rlstest helper for
+// test suites whose tests legitimately run DDL under the unprivileged
+// RLS role — re-running migrations, partition retention maintenance or
+// fault-injection ALTERs. Plain table privileges (rlstest.GrantAll) are
+// not enough for those: Postgres requires table ownership for DDL.
+//
+// Transferring ownership to the test role is safe for the isolation
+// guarantees because frame installs its tenancy policies with FORCE
+// ROW LEVEL SECURITY, which applies RLS to the table owner as well.
+package rlsadmin
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/pitabwire/frame/frametests/rlstest"
+
+	// Pull in the pgx stdlib driver so database/sql can dial postgres.
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// GrantOwnership makes the rlstest role the owner of every table,
+// sequence and non-extension function in the public schema and allows
+// it to create new relations. Function ownership is needed because
+// re-running migrations re-issues CREATE OR REPLACE FUNCTION for
+// frame's app_tenancy_matches helper. Must be invoked AFTER migration
+// (alongside rlstest.GrantAll) so all objects exist. Idempotent.
+func GrantOwnership(ctx context.Context, dsn string) error {
+	adminDB, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return fmt.Errorf("rlsadmin: open admin db: %w", err)
+	}
+	defer adminDB.Close()
+
+	stmts := []string{
+		`GRANT CREATE ON SCHEMA public TO ` + rlstest.Role,
+		`DO $$
+		DECLARE r record;
+		BEGIN
+			FOR r IN SELECT tablename AS name FROM pg_tables WHERE schemaname = 'public' LOOP
+				EXECUTE format('ALTER TABLE public.%I OWNER TO ` + rlstest.Role + `', r.name);
+			END LOOP;
+			FOR r IN SELECT sequencename AS name FROM pg_sequences WHERE schemaname = 'public' LOOP
+				EXECUTE format('ALTER SEQUENCE public.%I OWNER TO ` + rlstest.Role + `', r.name);
+			END LOOP;
+			FOR r IN
+				SELECT p.oid::regprocedure AS name
+				FROM pg_proc p
+				JOIN pg_namespace n ON p.pronamespace = n.oid
+				WHERE n.nspname = 'public'
+				AND NOT EXISTS (
+					SELECT 1 FROM pg_depend d
+					WHERE d.objid = p.oid AND d.deptype = 'e'
+				)
+			LOOP
+				EXECUTE format('ALTER FUNCTION %s OWNER TO ` + rlstest.Role + `', r.name);
+			END LOOP;
+		END $$`,
+	}
+	for _, stmt := range stmts {
+		if _, err = adminDB.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("rlsadmin: %s: %w", stmt, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

frame ≥v1.95 installs tenant-isolation RLS policies during `pool.Migrate`, but our suites ran every query as the testcontainer **superuser**, which bypasses `FORCE ROW LEVEL SECURITY` — so isolation was never actually exercised. This PR wires frame v1.98.2's `frametests/rlstest` into all four app base test suites so application queries run under an unprivileged role, and adds genuine cross-tenant isolation tests.

### Wiring (apps/default, devices, settings, geolocation `tests/base_testsuite.go`)
- `rlstest.CreateRole` before service init, `frame.WithTenancyProvider(rlstest.New())` on the service, `rlstest.GrantAll` + `rlsadmin.GrantOwnership` after migration, then `Enable()` — mirroring the working pattern in service-fintech.
- New `internal/rlsadmin` helper transfers table/sequence/function ownership to the test role. Postgres requires ownership for DDL, and several tests legitimately run DDL under the dropped role (re-running `Migrate`, geolocation retention partition maintenance, fault-injection `ALTER TABLE`). `FORCE RLS` applies to the owner too, so isolation stays enforced.
- Test services are now stopped via `t.Cleanup`, fixing a **pre-existing** connection-exhaustion flake (`FATAL: sorry, too many clients already`) reproducible on main.

### Production bug found and fixed
`apps/settings/service/repository/migrate.go` registered models **by value** (`models.SettingRef{}`), but `tenancy.Tenanted` is only satisfied by `*data.BaseModel` pointer receivers — so the settings models were **silently skipped during tenancy enrolment and no RLS policies were ever installed** on `setting_refs`, `setting_vals` and `setting_audits`. Registered as pointers now; the new isolation test fails without this fix and passes with it.

### New isolation tests
- `apps/default/service/repository/tenant_isolation_test.go`: rosters and contact verifications created by tenant A are invisible to tenant B.
- `apps/settings/service/business/settings_isolation_test.go`: setting refs/values created by tenant A are invisible to tenant B.

Deliberately cross-tenant reads (profiles/contacts via `security.SkipTenancyChecksOnClaims`) are untouched; the existing cross-tenant `GetByID`/`GetByContact` tests still pass.

## Testing
- `go test ./... -count=1`: all packages pass.
- `golangci-lint run` on changed packages: 0 issues; `go build ./...` clean.