### PR TITLE
chore(ui): profile+geolocation 0.2.2 — ui_core ^0.4.0

### DIFF
--- a/ui/geolocation/pubspec.yaml
+++ b/ui/geolocation/pubspec.yaml
@@ -1,7 +1,7 @@
 name: antinvestor_ui_geolocation
 description: >
   Geolocation UI library for Antinvestor. Location tracking, areas, routes, events.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/antinvestor/service-profile
 homepage: https://github.com/antinvestor/service-profile/tree/main/ui/geolocation
 issue_tracker: https://github.com/antinvestor/service-profile/issues
@@ -18,7 +18,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  antinvestor_ui_core: ^0.2.0
+  antinvestor_ui_core: ^0.4.0
   antinvestor_api_geolocation: ^0.1.0
   antinvestor_api_common: ^1.52.0
   connectrpc: ^1.0.0

--- a/ui/profile/pubspec.yaml
+++ b/ui/profile/pubspec.yaml
@@ -2,7 +2,7 @@ name: antinvestor_ui_profile
 description: >
   Profile management UI library for Antinvestor. Embeddable screens and widgets
   for profiles, contacts, addresses, relationships, and roster management.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/antinvestor/service-profile
 homepage: https://github.com/antinvestor/service-profile/tree/main/ui/profile
 issue_tracker: https://github.com/antinvestor/service-profile/issues
@@ -19,7 +19,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  antinvestor_ui_core: ^0.2.0
+  antinvestor_ui_core: ^0.4.0
   antinvestor_api_profile: ^1.52.0
   image_picker: ^1.1.2
   antinvestor_api_common: ^1.52.0


### PR DESCRIPTION
Aligns published constraints with reality (path overrides had been masking ^0.2.0 staleness). Both published to pub.dev; analyze clean against hosted core 0.4.1.