### PR TITLE
feat(metrics): migrate devices and geolocation instruments to BusinessMetrics

### DIFF
--- a/apps/devices/service/caching/metrics.go
+++ b/apps/devices/service/caching/metrics.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pitabwire/frame/telemetry"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -16,38 +15,34 @@ const instrumentationName = "devices/caching"
 //nolint:gochecknoglobals // OpenTelemetry instruments must be global for reuse
 var Tracer = telemetry.NewTracer(instrumentationName)
 
-// Metric instruments for cache observability.
+// Metric instruments for cache observability. Created through the
+// BusinessMetrics factory so every measurement is transparently
+// tenant-scoped (tenant_id/partition_id from the context's claims).
 //
 //nolint:gochecknoglobals // OpenTelemetry instruments must be global for reuse
 var (
-	cacheHitCounter  = telemetry.DimensionlessMeasure(instrumentationName, "cache_hits", "Number of cache hits")
-	cacheMissCounter = telemetry.DimensionlessMeasure(instrumentationName, "cache_misses", "Number of cache misses")
-	rateLimitCounter = telemetry.DimensionlessMeasure(
-		instrumentationName,
-		"rate_limited",
+	businessMetrics  = telemetry.NewBusinessMetrics(instrumentationName)
+	cacheHitCounter  = businessMetrics.Counter("devices/caching/cache_hits", "Number of cache hits")
+	cacheMissCounter = businessMetrics.Counter("devices/caching/cache_misses", "Number of cache misses")
+	rateLimitCounter = businessMetrics.Counter(
+		"devices/caching/rate_limited",
 		"Number of rate-limited requests",
 	)
 )
 
 // RecordCacheHit records a cache hit for the given cache type.
 func RecordCacheHit(ctx context.Context, cacheType string) {
-	cacheHitCounter.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("cache_type", cacheType),
-	))
+	cacheHitCounter.Add(ctx, 1, attribute.String("cache_type", cacheType))
 }
 
 // RecordCacheMiss records a cache miss for the given cache type.
 func RecordCacheMiss(ctx context.Context, cacheType string) {
-	cacheMissCounter.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("cache_type", cacheType),
-	))
+	cacheMissCounter.Add(ctx, 1, attribute.String("cache_type", cacheType))
 }
 
 // RecordRateLimited records a rate-limited request for the given operation.
 func RecordRateLimited(ctx context.Context, operation string) {
-	rateLimitCounter.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("operation", operation),
-	))
+	rateLimitCounter.Add(ctx, 1, attribute.String("operation", operation))
 }
 
 // StartSpan creates a new trace span for a device service operation.

--- a/apps/geolocation/service/observability/metrics.go
+++ b/apps/geolocation/service/observability/metrics.go
@@ -6,64 +6,74 @@ import (
 
 	"github.com/pitabwire/frame/telemetry"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 )
 
 const pkgName = "service_geolocation"
 
 // Metrics holds pre-allocated OTel instruments for the geolocation service.
-// Instruments are created once at startup and reused for every measurement.
+// Instruments are created once at startup through the BusinessMetrics
+// factory, so every measurement is transparently tenant-scoped
+// (tenant_id/partition_id derived from the context's security claims).
 type Metrics struct {
 	tracer telemetry.Tracer
 
 	// Ingestion metrics.
-	ingestBatchLatency metric.Float64Histogram
-	ingestAccepted     metric.Int64Counter
-	ingestRejected     metric.Int64Counter
+	ingestBatchLatency telemetry.Histogram
+	ingestAccepted     telemetry.Counter
+	ingestRejected     telemetry.Counter
 
 	// Geofence metrics.
-	geofenceEvalLatency metric.Float64Histogram
-	geofenceTransitions metric.Int64Counter
+	geofenceEvalLatency telemetry.Histogram
+	geofenceTransitions telemetry.Counter
 
 	// Route deviation metrics.
-	routeDeviationEvalLatency metric.Float64Histogram
-	routeDeviationTransitions metric.Int64Counter
+	routeDeviationEvalLatency telemetry.Histogram
+	routeDeviationTransitions telemetry.Counter
 
 	// Proximity metrics.
-	proximityQueryLatency metric.Float64Histogram
+	proximityQueryLatency telemetry.Histogram
 }
 
 // NewMetrics creates and registers all OTel instruments for the geolocation service.
 func NewMetrics() *Metrics {
 	t := telemetry.NewTracer(pkgName)
+	bm := telemetry.NewBusinessMetrics(pkgName)
 
 	return &Metrics{
-		tracer:             t,
-		ingestBatchLatency: telemetry.LatencyMeasure(pkgName + "/ingestion"),
-		ingestAccepted: telemetry.DimensionlessMeasure(
-			pkgName,
-			"/ingestion/accepted",
+		tracer: t,
+		ingestBatchLatency: bm.Histogram(
+			pkgName+"/ingestion/latency",
+			"Latency distribution of batch ingestions",
+		),
+		ingestAccepted: bm.Counter(
+			pkgName+"/ingestion/accepted",
 			"Number of accepted location points",
 		),
-		ingestRejected: telemetry.DimensionlessMeasure(
-			pkgName,
-			"/ingestion/rejected",
+		ingestRejected: bm.Counter(
+			pkgName+"/ingestion/rejected",
 			"Number of rejected location points",
 		),
-		geofenceEvalLatency: telemetry.LatencyMeasure(pkgName + "/geofence"),
-		geofenceTransitions: telemetry.DimensionlessMeasure(
-			pkgName,
-			"/geofence/transitions",
+		geofenceEvalLatency: bm.Histogram(
+			pkgName+"/geofence/latency",
+			"Latency distribution of geofence evaluations",
+		),
+		geofenceTransitions: bm.Counter(
+			pkgName+"/geofence/transitions",
 			"Number of geofence state transitions",
 		),
-		routeDeviationEvalLatency: telemetry.LatencyMeasure(pkgName + "/route_deviation"),
-		routeDeviationTransitions: telemetry.DimensionlessMeasure(
-			pkgName,
-			"/route_deviation/transitions",
+		routeDeviationEvalLatency: bm.Histogram(
+			pkgName+"/route_deviation/latency",
+			"Latency distribution of route deviation evaluations",
+		),
+		routeDeviationTransitions: bm.Counter(
+			pkgName+"/route_deviation/transitions",
 			"Number of route deviation state transitions",
 		),
-		proximityQueryLatency: telemetry.LatencyMeasure(pkgName + "/proximity"),
+		proximityQueryLatency: bm.Histogram(
+			pkgName+"/proximity/latency",
+			"Latency distribution of proximity queries",
+		),
 	}
 }
 
@@ -99,9 +109,7 @@ func (m *Metrics) RecordGeofenceEval(ctx context.Context, elapsed time.Duration)
 
 // RecordGeofenceTransition records a geofence state transition (enter/exit/dwell).
 func (m *Metrics) RecordGeofenceTransition(ctx context.Context, eventType string) {
-	m.geofenceTransitions.Add(ctx, 1,
-		metric.WithAttributes(attribute.String("event_type", eventType)),
-	)
+	m.geofenceTransitions.Add(ctx, 1, attribute.String("event_type", eventType))
 }
 
 // RecordRouteDeviationEval records metrics for a route deviation evaluation.
@@ -111,9 +119,7 @@ func (m *Metrics) RecordRouteDeviationEval(ctx context.Context, elapsed time.Dur
 
 // RecordRouteDeviationTransition records a route deviation state transition.
 func (m *Metrics) RecordRouteDeviationTransition(ctx context.Context, eventType string) {
-	m.routeDeviationTransitions.Add(ctx, 1,
-		metric.WithAttributes(attribute.String("event_type", eventType)),
-	)
+	m.routeDeviationTransitions.Add(ctx, 1, attribute.String("event_type", eventType))
 }
 
 // RecordProximityQuery records metrics for a proximity query.
@@ -123,6 +129,6 @@ func (m *Metrics) RecordProximityQuery(
 	resultCount int,
 ) {
 	m.proximityQueryLatency.Record(ctx, float64(elapsed.Milliseconds()),
-		metric.WithAttributes(attribute.Int("result_count", resultCount)),
+		attribute.Int("result_count", resultCount),
 	)
 }

--- a/apps/geolocation/service/observability/metrics_test.go
+++ b/apps/geolocation/service/observability/metrics_test.go
@@ -5,7 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pitabwire/frame/security"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestMetricsRecorders(t *testing.T) {
@@ -22,4 +26,85 @@ func TestMetricsRecorders(t *testing.T) {
 	metrics.RecordRouteDeviationEval(ctx, time.Second)
 	metrics.RecordRouteDeviationTransition(ctx, "deviated")
 	metrics.RecordProximityQuery(ctx, time.Second, 3)
+}
+
+// findMetric returns the metric with the given name, or nil when absent.
+func findMetric(rm metricdata.ResourceMetrics, name string) *metricdata.Metrics {
+	for _, sm := range rm.ScopeMetrics {
+		for i := range sm.Metrics {
+			if sm.Metrics[i].Name == name {
+				return &sm.Metrics[i]
+			}
+		}
+	}
+	return nil
+}
+
+// TestMetricsTenantAttribution proves, via a ManualReader, that instruments
+// created through the BusinessMetrics factory keep their exact metric names
+// and automatically attach tenant_id/partition_id from the context claims
+// alongside the explicit non-tenant attributes.
+func TestMetricsTenantAttribution(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+
+	metrics := NewMetrics()
+
+	claims := &security.AuthenticationClaims{
+		TenantID:    "tenant-geo-attr",
+		PartitionID: "partition-geo-attr",
+	}
+	claims.Subject = "subject-geo-attr"
+	ctx := claims.ClaimsToContext(context.Background())
+
+	metrics.RecordGeofenceTransition(ctx, "enter")
+	metrics.RecordIngestBatch(ctx, 3, 1, 250*time.Millisecond)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	// Counter: exact name preserved, tenant + event_type attributes present.
+	transitions := findMetric(rm, "service_geolocation/geofence/transitions")
+	require.NotNil(t, transitions, "geofence transitions counter must keep its metric name")
+	sum, ok := transitions.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "transitions must be an int64 sum")
+
+	var matched bool
+	for _, dp := range sum.DataPoints {
+		tenant, hasTenant := dp.Attributes.Value("tenant_id")
+		if !hasTenant || tenant.AsString() != "tenant-geo-attr" {
+			continue
+		}
+		matched = true
+		partition, hasPartition := dp.Attributes.Value("partition_id")
+		require.True(t, hasPartition, "partition_id must accompany tenant_id")
+		require.Equal(t, "partition-geo-attr", partition.AsString())
+		eventType, hasEventType := dp.Attributes.Value("event_type")
+		require.True(t, hasEventType, "non-tenant attributes must be preserved")
+		require.Equal(t, "enter", eventType.AsString())
+		require.Equal(t, int64(1), dp.Value)
+	}
+	require.True(t, matched, "expected a datapoint attributed to tenant-geo-attr")
+
+	// Histogram: exact latency metric name preserved with tenant attribution.
+	latency := findMetric(rm, "service_geolocation/ingestion/latency")
+	require.NotNil(t, latency, "ingestion latency histogram must keep its metric name")
+	hist, ok := latency.Data.(metricdata.Histogram[float64])
+	require.True(t, ok, "latency must be a float64 histogram")
+
+	var histMatched bool
+	for _, dp := range hist.DataPoints {
+		tenant, hasTenant := dp.Attributes.Value("tenant_id")
+		if !hasTenant || tenant.AsString() != "tenant-geo-attr" {
+			continue
+		}
+		histMatched = true
+		require.Equal(t, uint64(1), dp.Count)
+		require.InEpsilon(t, 250.0, dp.Sum, 0.001)
+	}
+	require.True(t, histMatched, "expected a latency datapoint attributed to tenant-geo-attr")
+
+	// Companion counters from the same batch keep their names too.
+	require.NotNil(t, findMetric(rm, "service_geolocation/ingestion/accepted"))
+	require.NotNil(t, findMetric(rm, "service_geolocation/ingestion/rejected"))
 }

--- a/go.mod
+++ b/go.mod
@@ -25,13 +25,13 @@ require (
 	github.com/google/gnostic v0.7.1
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/mssola/user_agent v0.6.0
-	github.com/pitabwire/frame v1.98.2
+	github.com/pitabwire/frame v1.98.4
 	github.com/pitabwire/util v0.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/ttacon/libphonenumber v1.2.1
 	go.opentelemetry.io/otel v1.44.0
-	go.opentelemetry.io/otel/metric v1.44.0
+	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/sync v0.21.0
 	google.golang.org/grpc v1.81.1
@@ -166,9 +166,9 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/log v0.20.0 // indirect
+	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.20.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame v1.98.2 h1:Kv/9w4+P/2En9hGBrXawNPOk0DMwek8HUg0A21WMnu8=
-github.com/pitabwire/frame v1.98.2/go.mod h1:k6TV0rPXAgR8hG5CH3vjqepmitIiw5EvHVM7dfR1xV8=
+github.com/pitabwire/frame v1.98.4 h1:yGrVLMlc+2rqHMoXL124VZ7RJW/zHyqkaZ4R7TP7HiQ=
+github.com/pitabwire/frame v1.98.4/go.mod h1:k6TV0rPXAgR8hG5CH3vjqepmitIiw5EvHVM7dfR1xV8=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=


### PR DESCRIPTION
## Summary
- Migrate `apps/devices/service/caching/metrics.go` (3 instruments) and `apps/geolocation/service/observability/metrics.go` (8 instruments) to frame's tenant-scoped `telemetry.NewBusinessMetrics` factory, so every measurement transparently carries `tenant_id`/`partition_id` from the context's security claims.
- Pin `github.com/pitabwire/frame` to **v1.98.4** (first release containing `telemetry.NewBusinessMetrics`).

## Metric names
All names preserved:
- `service_geolocation/ingestion/{latency,accepted,rejected}`, `service_geolocation/geofence/{latency,transitions}`, `service_geolocation/route_deviation/{latency,transitions}`, `service_geolocation/proximity/latency`
- `devices/caching/{cache_hits,cache_misses,rate_limited}` — note: the previous `DimensionlessMeasure(pkg, name)` concatenation actually emitted `devices/cachingcache_hits` (missing separator); these now carry the intended `devices/caching/` prefix.

Non-tenant attributes preserved: `cache_type`, `operation`, `event_type`, `result_count`.

## Tenant attribution at call sites
- Connect handlers receive claims via the auth middleware.
- Queue consumers restore claims via `models.ContextWithEventTenancy` before recording.
- Unauthenticated/system paths record without tenant attributes (by factory design).

## Testing
- New `TestMetricsTenantAttribution` (ManualReader) proves exact metric names and automatic `tenant_id`/`partition_id` attribution alongside `event_type`/histogram values.
- Full RLS-enabled suites: `go test ./apps/devices/... ./apps/geolocation/... -count=1` — all green (11 packages ok).
- `go build ./...` clean; `golangci-lint` 0 issues on changed packages.