### PR TITLE
feat(ui/profile): devices & geolocation activity from the Thesa analytics gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ vendor/
 .tmp/
 WORK_STATE.md
 
+
+# Local-only pub dependency overrides (unpublished ui_core)
+pubspec_overrides.yaml

--- a/ui/profile/lib/antinvestor_ui_profile.dart
+++ b/ui/profile/lib/antinvestor_ui_profile.dart
@@ -1,3 +1,8 @@
+// Analytics
+export 'src/analytics/analytics_states.dart';
+export 'src/analytics/profile_activity_section.dart';
+export 'src/analytics/profile_analytics_spec.dart';
+
 // Routing
 export 'src/routing/profile_route_module.dart';
 

--- a/ui/profile/lib/src/analytics/analytics_states.dart
+++ b/ui/profile/lib/src/analytics/analytics_states.dart
@@ -1,0 +1,60 @@
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+import 'package:flutter/material.dart';
+
+/// Maps analytics gate failures to friendly, user-facing messages.
+///
+/// The gate rejects malformed or disallowed queries with 400, tenant-scope
+/// problems with 401/403, and signals backend outages with 5xx; none of
+/// those should surface as raw exception strings.
+String analyticsFailureMessage(Object error) {
+  if (error is AnalyticsQueryException) {
+    final status = error.statusCode;
+    if (status == 400) {
+      return 'This metric is not supported by the analytics service yet.';
+    }
+    if (status == 401 || status == 403) {
+      return 'You do not have access to analytics for this tenant.';
+    }
+    if (status >= 500) {
+      return 'Analytics is temporarily unavailable. Please try again '
+          'shortly.';
+    }
+    return 'The analytics request failed (HTTP $status).';
+  }
+  return 'Could not load analytics data.';
+}
+
+/// Friendly inline error state for a failed analytics query.
+class AnalyticsErrorCard extends StatelessWidget {
+  const AnalyticsErrorCard({super.key, required this.error, this.onRetry});
+
+  final Object error;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cs.errorContainer.withValues(alpha: 0.25),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.cloud_off_outlined, color: cs.error, size: 20),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              analyticsFailureMessage(error),
+              style: theme.textTheme.bodySmall?.copyWith(color: cs.error),
+            ),
+          ),
+          if (onRetry != null)
+            TextButton(onPressed: onRetry, child: const Text('Retry')),
+        ],
+      ),
+    );
+  }
+}

--- a/ui/profile/lib/src/analytics/profile_activity_section.dart
+++ b/ui/profile/lib/src/analytics/profile_activity_section.dart
@@ -1,0 +1,163 @@
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'analytics_states.dart';
+import 'profile_analytics_spec.dart';
+
+/// Devices & geolocation activity from the Thesa analytics gate.
+///
+/// Complements the entity counts on the profile analytics screen with
+/// tenant-scoped activity signals: device cache hits vs misses (with a
+/// client-computed hit ratio) and geolocation ingestion accepted vs
+/// rejected time series.
+class ProfileActivitySection extends ConsumerStatefulWidget {
+  const ProfileActivitySection({super.key});
+
+  @override
+  ConsumerState<ProfileActivitySection> createState() =>
+      _ProfileActivitySectionState();
+}
+
+class _ProfileActivitySectionState
+    extends ConsumerState<ProfileActivitySection> {
+  AnalyticsTimeRange _range = AnalyticsTimeRange.last30Days();
+
+  void _refresh() {
+    ref.invalidate(serviceMetricsProvider);
+    ref.invalidate(serviceTimeSeriesProvider);
+  }
+
+  /// Appends the client-computed cache hit ratio to the gate-provided
+  /// hit/miss counters. The gate is queried per metric; the ratio is
+  /// derived locally so no extra endpoint is needed.
+  List<MetricValue> _withHitRatio(List<MetricValue> metrics) {
+    double? hits;
+    double? misses;
+    for (final metric in metrics) {
+      if (metric.key == 'cache_hits') hits = metric.value;
+      if (metric.key == 'cache_misses') misses = metric.value;
+    }
+    final total = (hits ?? 0) + (misses ?? 0);
+    if (hits == null || misses == null || total <= 0) return metrics;
+    return [
+      ...metrics,
+      MetricValue(
+        key: 'cache_hit_ratio',
+        label: 'Cache Hit Ratio',
+        value: hits / total * 100,
+        unit: 'percent',
+        icon: Icons.speed_outlined,
+      ),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final metricsAsync = ref.watch(
+      serviceMetricsProvider(
+        ServiceMetricsParams(profileAnalyticsSpec.service, timeRange: _range),
+      ),
+    );
+    final ingestionAsync = [
+      for (final metric in geoIngestionMetrics)
+        ref.watch(
+          serviceTimeSeriesProvider(
+            ServiceTimeSeriesParams(
+              profileAnalyticsSpec.service,
+              metric,
+              timeRange: _range,
+            ),
+          ),
+        ),
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                'Devices & Geolocation Activity',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              tooltip: 'Refresh activity',
+              onPressed: _refresh,
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: TimeRangeSelector(
+            value: _range,
+            onChanged: (range) => setState(() => _range = range),
+          ),
+        ),
+        const SizedBox(height: 16),
+        metricsAsync.when(
+          data: (metrics) => MetricsRow(metrics: _withHitRatio(metrics)),
+          loading: () =>
+              const MetricsRow(metrics: [], isLoading: true, skeletonCount: 3),
+          error: (error, _) =>
+              AnalyticsErrorCard(error: error, onRetry: _refresh),
+        ),
+        const SizedBox(height: 16),
+        _ingestionChart(theme, ingestionAsync),
+      ],
+    );
+  }
+
+  /// Geolocation ingestion accepted vs rejected as one combined chart.
+  Widget _ingestionChart(
+    ThemeData theme,
+    List<AsyncValue<List<TimeSeries>>> asyncSeries,
+  ) {
+    final cs = theme.colorScheme;
+
+    Widget body;
+    final failed = asyncSeries.where((a) => a.hasError).toList();
+    if (failed.isNotEmpty) {
+      body = AnalyticsErrorCard(error: failed.first.error!, onRetry: _refresh);
+    } else if (asyncSeries.any((a) => a.isLoading)) {
+      body = const SizedBox(
+        height: 240,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    } else {
+      body = TimeSeriesChart(
+        series: [for (final a in asyncSeries) ...a.requireValue],
+        granularity: _range.granularity,
+      );
+    }
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: cs.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Geolocation Ingestion (accepted vs rejected)',
+            style: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 16),
+          body,
+        ],
+      ),
+    );
+  }
+}

--- a/ui/profile/lib/src/analytics/profile_analytics_spec.dart
+++ b/ui/profile/lib/src/analytics/profile_analytics_spec.dart
@@ -1,0 +1,53 @@
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+import 'package:flutter/material.dart';
+
+/// Metric names emitted by the devices caching layer
+/// (`apps/devices/service/caching`) and the geolocation ingestion pipeline
+/// (`apps/geolocation/service/observability`).
+const deviceCacheHitsMetric = 'devices/caching/cache_hits';
+const deviceCacheMissesMetric = 'devices/caching/cache_misses';
+const geoIngestionAcceptedMetric = 'service_geolocation/ingestion/accepted';
+const geoIngestionRejectedMetric = 'service_geolocation/ingestion/rejected';
+
+/// The geolocation ingestion outcomes charted as activity time series.
+const geoIngestionMetrics = [
+  geoIngestionAcceptedMetric,
+  geoIngestionRejectedMetric,
+];
+
+/// Analytics catalog for the profile service family, served by the Thesa
+/// analytics gate.
+///
+/// Profile entity counts stay on the profile API; this spec covers the
+/// devices/geolocation activity signals. Tenant scoping is injected
+/// server-side from the caller's JWT; no tenant filters are (or may be)
+/// declared here.
+const profileAnalyticsSpec = ServiceAnalyticsSpec(
+  service: 'profile',
+  kpis: [
+    KpiSpec(
+      'cache_hits',
+      label: 'Device Cache Hits',
+      metric: deviceCacheHitsMetric,
+      unit: 'count',
+      icon: Icons.memory_outlined,
+    ),
+    KpiSpec(
+      'cache_misses',
+      label: 'Device Cache Misses',
+      metric: deviceCacheMissesMetric,
+      unit: 'count',
+      icon: Icons.sd_card_alert_outlined,
+    ),
+  ],
+  charts: [
+    ChartConfig.timeSeries(
+      geoIngestionAcceptedMetric,
+      label: 'Accepted Points',
+    ),
+    ChartConfig.timeSeries(
+      geoIngestionRejectedMetric,
+      label: 'Rejected Points',
+    ),
+  ],
+);

--- a/ui/profile/lib/src/screens/profile_analytics_screen.dart
+++ b/ui/profile/lib/src/screens/profile_analytics_screen.dart
@@ -2,6 +2,7 @@ import 'package:antinvestor_api_profile/antinvestor_api_profile.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../analytics/profile_activity_section.dart';
 import '../providers/profile_providers.dart';
 
 /// Profile service dashboard with KPI cards showing profile statistics.
@@ -16,20 +17,22 @@ class ProfileAnalyticsScreen extends ConsumerWidget {
     final profiles =
         asyncProfiles.whenOrNull(data: (d) => d) ?? <ProfileObject>[];
     final totalCount = profiles.length;
-    final personCount =
-        profiles.where((p) => p.type == ProfileType.PERSON).length;
-    final institutionCount =
-        profiles.where((p) => p.type == ProfileType.INSTITUTION).length;
-    final botCount =
-        profiles.where((p) => p.type == ProfileType.BOT).length;
-    final activeCount =
-        profiles.where((p) => p.state == STATE.ACTIVE).length;
-    final totalContacts =
-        profiles.fold<int>(0, (sum, p) => sum + p.contacts.length);
+    final personCount = profiles
+        .where((p) => p.type == ProfileType.PERSON)
+        .length;
+    final institutionCount = profiles
+        .where((p) => p.type == ProfileType.INSTITUTION)
+        .length;
+    final botCount = profiles.where((p) => p.type == ProfileType.BOT).length;
+    final activeCount = profiles.where((p) => p.state == STATE.ACTIVE).length;
+    final totalContacts = profiles.fold<int>(
+      0,
+      (sum, p) => sum + p.contacts.length,
+    );
     final verifiedContacts = profiles.fold<int>(
-        0,
-        (sum, p) =>
-            sum + p.contacts.where((c) => c.verified).length);
+      0,
+      (sum, p) => sum + p.contacts.where((c) => c.verified).length,
+    );
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(24),
@@ -39,19 +42,28 @@ class ProfileAnalyticsScreen extends ConsumerWidget {
           // Header
           Row(
             children: [
-              Icon(Icons.analytics_outlined,
-                  size: 28, color: theme.colorScheme.primary),
+              Icon(
+                Icons.analytics_outlined,
+                size: 28,
+                color: theme.colorScheme.primary,
+              ),
               const SizedBox(width: 12),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text('Profile Service',
-                        style: theme.textTheme.headlineSmall
-                            ?.copyWith(fontWeight: FontWeight.w600)),
-                    Text('Service analytics and overview',
-                        style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.onSurfaceVariant)),
+                    Text(
+                      'Profile Service',
+                      style: theme.textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    Text(
+                      'Service analytics and overview',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
                   ],
                 ),
               ),
@@ -71,8 +83,8 @@ class ProfileAnalyticsScreen extends ConsumerWidget {
               final crossAxisCount = constraints.maxWidth > 900
                   ? 4
                   : constraints.maxWidth > 600
-                      ? 3
-                      : 2;
+                  ? 3
+                  : 2;
               return Wrap(
                 spacing: 16,
                 runSpacing: 16,
@@ -82,8 +94,8 @@ class ProfileAnalyticsScreen extends ConsumerWidget {
                     value: '$totalCount',
                     icon: Icons.people_outlined,
                     color: theme.colorScheme.primary,
-                    width: (constraints.maxWidth -
-                            (crossAxisCount - 1) * 16) /
+                    width:
+                        (constraints.maxWidth - (crossAxisCount - 1) * 16) /
                         crossAxisCount,
                   ),
                   _KpiCard(
@@ -91,8 +103,8 @@ class ProfileAnalyticsScreen extends ConsumerWidget {
                     value: '$personCount',
                     icon: Icons.person_outlined,
                     color: Colors.blue,
-                    width: (constraints.maxWidth -
-                            (crossAxisCount - 1) * 16) /
+                    width:
+                        (constraints.maxWidth - (crossAxisCount - 1) * 16) /
                         crossAxisCount,
                   ),
                   _KpiCard(
@@ -100,8 +112,8 @@ class ProfileAnalyticsScreen extends ConsumerWidget {
                     value: '$institutionCount',
                     icon: Icons.business_outlined,
                     color: Colors.green,
-                    width: (constraints.maxWidth -
-                            (crossAxisCount - 1) * 16) /
+                    width:
+                        (constraints.maxWidth - (crossAxisCount - 1) * 16) /
                         crossAxisCount,
                   ),
                   _KpiCard(
@@ -109,8 +121,8 @@ class ProfileAnalyticsScreen extends ConsumerWidget {
                     value: '$botCount',
                     icon: Icons.smart_toy_outlined,
                     color: Colors.orange,
-                    width: (constraints.maxWidth -
-                            (crossAxisCount - 1) * 16) /
+                    width:
+                        (constraints.maxWidth - (crossAxisCount - 1) * 16) /
                         crossAxisCount,
                   ),
                   _KpiCard(
@@ -118,8 +130,8 @@ class ProfileAnalyticsScreen extends ConsumerWidget {
                     value: '$activeCount',
                     icon: Icons.check_circle_outline,
                     color: Colors.teal,
-                    width: (constraints.maxWidth -
-                            (crossAxisCount - 1) * 16) /
+                    width:
+                        (constraints.maxWidth - (crossAxisCount - 1) * 16) /
                         crossAxisCount,
                   ),
                   _KpiCard(
@@ -127,8 +139,8 @@ class ProfileAnalyticsScreen extends ConsumerWidget {
                     value: '$totalContacts',
                     icon: Icons.contact_phone_outlined,
                     color: Colors.indigo,
-                    width: (constraints.maxWidth -
-                            (crossAxisCount - 1) * 16) /
+                    width:
+                        (constraints.maxWidth - (crossAxisCount - 1) * 16) /
                         crossAxisCount,
                   ),
                   _KpiCard(
@@ -136,8 +148,8 @@ class ProfileAnalyticsScreen extends ConsumerWidget {
                     value: '$verifiedContacts',
                     icon: Icons.verified_outlined,
                     color: Colors.purple,
-                    width: (constraints.maxWidth -
-                            (crossAxisCount - 1) * 16) /
+                    width:
+                        (constraints.maxWidth - (crossAxisCount - 1) * 16) /
                         crossAxisCount,
                   ),
                 ],
@@ -146,43 +158,9 @@ class ProfileAnalyticsScreen extends ConsumerWidget {
           ),
           const SizedBox(height: 32),
 
-          // Recent events (placeholder)
-          Text('Recent Events',
-              style: theme.textTheme.titleMedium
-                  ?.copyWith(fontWeight: FontWeight.w600)),
-          const SizedBox(height: 12),
-          Container(
-            width: double.infinity,
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(12),
-              border:
-                  Border.all(color: theme.colorScheme.outlineVariant),
-            ),
-            child: Column(
-              children: [
-                _EventTile(
-                  title: 'New profile registered',
-                  timeAgo: '5 mins ago',
-                  icon: Icons.person_add_outlined,
-                  color: Colors.green,
-                ),
-                const Divider(height: 1),
-                _EventTile(
-                  title: 'Contact verification completed',
-                  timeAgo: '20 mins ago',
-                  icon: Icons.verified_outlined,
-                  color: Colors.blue,
-                ),
-                const Divider(height: 1),
-                _EventTile(
-                  title: 'Profile merge executed',
-                  timeAgo: '1 hour ago',
-                  icon: Icons.merge_outlined,
-                  color: Colors.orange,
-                ),
-              ],
-            ),
-          ),
+          // Gate-backed devices/geolocation activity from the Thesa
+          // analytics API. Entity counts above stay on the profile API.
+          const ProfileActivitySection(),
         ],
       ),
     );
@@ -252,41 +230,6 @@ class _KpiCard extends StatelessWidget {
           ),
         ),
       ),
-    );
-  }
-}
-
-class _EventTile extends StatelessWidget {
-  const _EventTile({
-    required this.title,
-    required this.timeAgo,
-    required this.icon,
-    required this.color,
-  });
-
-  final String title;
-  final String timeAgo;
-  final IconData icon;
-  final Color color;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return ListTile(
-      leading: Container(
-        padding: const EdgeInsets.all(8),
-        decoration: BoxDecoration(
-          color: color.withAlpha(25),
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: Icon(icon, size: 18, color: color),
-      ),
-      title: Text(title,
-          style: theme.textTheme.bodyMedium
-              ?.copyWith(fontWeight: FontWeight.w500)),
-      trailing: Text(timeAgo,
-          style: theme.textTheme.bodySmall
-              ?.copyWith(color: theme.colorScheme.onSurfaceVariant)),
     );
   }
 }

--- a/ui/profile/pubspec.yaml
+++ b/ui/profile/pubspec.yaml
@@ -19,7 +19,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  antinvestor_ui_core: ^0.2.0
+  antinvestor_ui_core: ^0.5.0
   antinvestor_api_profile: ^1.52.0
   image_picker: ^1.1.2
   antinvestor_api_common: ^1.52.0
@@ -34,6 +34,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  http: ^1.6.0
   build_runner: ^2.13.1
   riverpod_generator: ^4.0.3
 

--- a/ui/profile/test/analytics/profile_activity_section_test.dart
+++ b/ui/profile/test/analytics/profile_activity_section_test.dart
@@ -1,0 +1,144 @@
+import 'dart:convert';
+
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+import 'package:antinvestor_ui_profile/antinvestor_ui_profile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+http.Response ok(Object payload) => http.Response(
+  json.encode(payload),
+  200,
+  headers: {'content-type': 'application/json'},
+);
+
+http.Response apiError(int status, String message) => http.Response(
+  json.encode({'error': message}),
+  status,
+  headers: {'content-type': 'application/json'},
+);
+
+/// Wires the section into a ProviderScope with a stubbed gate transport.
+Widget harness(
+  http.Response Function(String path, Map<String, dynamic> body) handler,
+) {
+  Future<http.Response> transport(String path, {Object? body}) async {
+    final decoded = json.decode(body! as String) as Map<String, dynamic>;
+    return handler(path, decoded);
+  }
+
+  return ProviderScope(
+    overrides: [
+      analyticsDataSourceProvider.overrideWithValue(
+        ThesaAnalyticsDataSource(
+          transport,
+          specs: const [profileAnalyticsSpec],
+        ),
+      ),
+    ],
+    child: const MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(child: ProfileActivitySection()),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets(
+    'renders cache KPIs with computed hit ratio and ingestion chart',
+    (tester) async {
+      await tester.pumpWidget(
+        harness((path, body) {
+          if (path.endsWith('/scalar')) {
+            return body['metric'] == deviceCacheHitsMetric
+                ? ok({'value': 75})
+                : ok({'value': 25});
+          }
+          return ok({
+            'points': [
+              {'timestamp': '2026-06-01T00:00:00Z', 'value': 5},
+              {'timestamp': '2026-06-02T00:00:00Z', 'value': 8},
+            ],
+          });
+        }),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Devices & Geolocation Activity'), findsOneWidget);
+      expect(find.text('Device Cache Hits'), findsOneWidget);
+      expect(find.text('75'), findsOneWidget);
+      expect(find.text('Device Cache Misses'), findsOneWidget);
+      expect(find.text('25'), findsOneWidget);
+      // Ratio is computed client-side: 75 / (75 + 25) = 75%.
+      expect(find.text('Cache Hit Ratio'), findsOneWidget);
+      expect(find.text('75.0%'), findsOneWidget);
+      expect(
+        find.text('Geolocation Ingestion (accepted vs rejected)'),
+        findsOneWidget,
+      );
+      expect(find.text('Accepted Points'), findsOneWidget);
+      expect(find.text('Rejected Points'), findsOneWidget);
+      expect(find.byType(TimeSeriesChart), findsOneWidget);
+    },
+  );
+
+  testWidgets('omits the hit ratio card when there is no cache traffic', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      harness((path, _) {
+        if (path.endsWith('/scalar')) return ok({'value': 0});
+        return ok({'points': []});
+      }),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Device Cache Hits'), findsOneWidget);
+    expect(find.text('Cache Hit Ratio'), findsNothing);
+    expect(find.text('No data'), findsOneWidget);
+  });
+
+  testWidgets('shows access message on 403 instead of raw error', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      harness((_, _) => apiError(403, 'tenant scope required')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('You do not have access to analytics'),
+      findsWidgets,
+    );
+    expect(find.textContaining('AnalyticsQueryException'), findsNothing);
+    expect(find.textContaining('tenant scope required'), findsNothing);
+  });
+
+  testWidgets('shows temporary outage message on 503', (tester) async {
+    await tester.pumpWidget(
+      harness((_, _) => apiError(503, 'backend unavailable')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('Analytics is temporarily unavailable'),
+      findsWidgets,
+    );
+    expect(find.text('Retry'), findsWidgets);
+  });
+
+  testWidgets('shows unsupported-metric message on 400', (tester) async {
+    await tester.pumpWidget(
+      harness((_, _) => apiError(400, 'metric not allowed')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('not supported by the analytics service'),
+      findsWidgets,
+    );
+    expect(find.textContaining('metric not allowed'), findsNothing);
+  });
+}

--- a/ui/profile/test/analytics/profile_analytics_screen_test.dart
+++ b/ui/profile/test/analytics/profile_analytics_screen_test.dart
@@ -1,0 +1,58 @@
+import 'dart:convert';
+
+import 'package:antinvestor_api_profile/antinvestor_api_profile.dart';
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+import 'package:antinvestor_ui_profile/antinvestor_ui_profile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+void main() {
+  testWidgets('keeps entity KPI cards and contains no placeholder event data', (
+    tester,
+  ) async {
+    Future<http.Response> transport(String path, {Object? body}) async {
+      final payload = path.endsWith('/scalar')
+          ? {'value': 0}
+          : {'points': <Object>[]};
+      return http.Response(
+        json.encode(payload),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          profileSearchProvider.overrideWith(
+            (ref, query) async => <ProfileObject>[],
+          ),
+          analyticsDataSourceProvider.overrideWithValue(
+            ThesaAnalyticsDataSource(
+              transport,
+              specs: const [profileAnalyticsSpec],
+            ),
+          ),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(body: ProfileAnalyticsScreen()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Entity-API counts stay.
+    expect(find.text('Total Profiles'), findsOneWidget);
+    expect(find.text('Person Profiles'), findsOneWidget);
+    expect(find.text('Verified Contacts'), findsOneWidget);
+
+    // The gate-backed activity section replaces the mock event feed.
+    expect(find.text('Devices & Geolocation Activity'), findsOneWidget);
+    expect(find.text('Recent Events'), findsNothing);
+    expect(find.text('New profile registered'), findsNothing);
+    expect(find.text('Contact verification completed'), findsNothing);
+    expect(find.text('Profile merge executed'), findsNothing);
+  });
+}

--- a/ui/profile/test/analytics/profile_analytics_spec_test.dart
+++ b/ui/profile/test/analytics/profile_analytics_spec_test.dart
@@ -1,0 +1,165 @@
+import 'dart:convert';
+
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+import 'package:antinvestor_ui_profile/antinvestor_ui_profile.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+/// A transport call recorded with its decoded JSON body.
+class RecordedRequest {
+  RecordedRequest(this.path, this.body);
+  final String path;
+  final Map<String, dynamic> body;
+}
+
+/// Records every request and answers via a per-test handler.
+class MockTransport {
+  MockTransport(this.handler);
+
+  final http.Response Function(String path, Map<String, dynamic> body) handler;
+  final List<RecordedRequest> requests = [];
+
+  Future<http.Response> call(String path, {Object? body}) async {
+    final decoded = json.decode(body! as String) as Map<String, dynamic>;
+    requests.add(RecordedRequest(path, decoded));
+    return handler(path, decoded);
+  }
+}
+
+http.Response ok(Object payload) => http.Response(
+  json.encode(payload),
+  200,
+  headers: {'content-type': 'application/json'},
+);
+
+final fixedRange = AnalyticsTimeRange(
+  start: DateTime.utc(2026, 6, 1),
+  end: DateTime.utc(2026, 6, 8),
+  granularity: TimeGranularity.day,
+);
+
+const fixedRangeJson = {
+  'start': '2026-06-01T00:00:00.000Z',
+  'end': '2026-06-08T00:00:00.000Z',
+};
+
+ThesaAnalyticsDataSource sourceWith(MockTransport transport) =>
+    ThesaAnalyticsDataSource(
+      transport.call,
+      specs: const [profileAnalyticsSpec],
+    );
+
+void main() {
+  group('device cache KPI contracts', () {
+    test('getMetrics posts one exact scalar body per cache counter', () async {
+      final transport = MockTransport((_, body) {
+        return body['metric'] == deviceCacheHitsMetric
+            ? ok({'value': 75})
+            : ok({'value': 25});
+      });
+      final source = sourceWith(transport);
+
+      final metrics = await source.getMetrics('profile', timeRange: fixedRange);
+
+      expect(transport.requests, hasLength(2));
+      expect(transport.requests.map((r) => r.path).toSet(), {
+        '/api/analytics/query/scalar',
+      });
+      expect(transport.requests[0].body, {
+        'metric': 'devices/caching/cache_hits',
+        'aggregation': 'sum',
+        'time_range': fixedRangeJson,
+      });
+      expect(transport.requests[1].body, {
+        'metric': 'devices/caching/cache_misses',
+        'aggregation': 'sum',
+        'time_range': fixedRangeJson,
+      });
+
+      expect(metrics.map((m) => m.key), ['cache_hits', 'cache_misses']);
+      expect(metrics[0].value, 75.0);
+      expect(metrics[1].value, 25.0);
+    });
+  });
+
+  group('geolocation ingestion contracts', () {
+    const expectedLabels = {
+      'service_geolocation/ingestion/accepted': 'Accepted Points',
+      'service_geolocation/ingestion/rejected': 'Rejected Points',
+    };
+
+    for (final entry in expectedLabels.entries) {
+      test('${entry.key} posts an exact sum time-series body', () async {
+        final transport = MockTransport(
+          (_, _) => ok({
+            'points': [
+              {'timestamp': '2026-06-01T00:00:00Z', 'value': 11},
+            ],
+          }),
+        );
+        final source = sourceWith(transport);
+
+        final series = await source.getTimeSeries(
+          'profile',
+          entry.key,
+          timeRange: fixedRange,
+        );
+
+        expect(
+          transport.requests.single.path,
+          '/api/analytics/query/timeseries',
+        );
+        expect(transport.requests.single.body, {
+          'metric': entry.key,
+          'aggregation': 'sum',
+          'time_range': fixedRangeJson,
+          'step': 'day',
+        });
+        expect(series.single.label, entry.value);
+        expect(series.single.points.single.value, 11.0);
+      });
+    }
+  });
+
+  group('tenancy', () {
+    test('never sends tenant_id or partition_id', () async {
+      final transport = MockTransport((_, _) => ok({'value': 1}));
+      final source = sourceWith(transport);
+
+      await source.getMetrics('profile', timeRange: fixedRange);
+      for (final metric in geoIngestionMetrics) {
+        await source.getTimeSeries('profile', metric, timeRange: fixedRange);
+      }
+
+      for (final request in transport.requests) {
+        final filters =
+            request.body['filters'] as Map<String, dynamic>? ?? const {};
+        expect(filters.keys, isNot(contains('tenant_id')));
+        expect(filters.keys, isNot(contains('partition_id')));
+      }
+    });
+
+    test('spec declares no tenancy filters anywhere', () {
+      expect(profileAnalyticsSpec.baseFilters, isEmpty);
+      for (final kpi in profileAnalyticsSpec.kpis) {
+        expect(kpi.filters, isNull);
+      }
+      for (final chart in profileAnalyticsSpec.charts) {
+        expect(chart.filters, isNull);
+      }
+    });
+  });
+
+  group('spec declaration', () {
+    test('covers cache counters and ingestion outcomes', () {
+      expect(profileAnalyticsSpec.service, 'profile');
+      expect(profileAnalyticsSpec.metricKeys, ['cache_hits', 'cache_misses']);
+      for (final metric in geoIngestionMetrics) {
+        final chart = profileAnalyticsSpec.chartFor(metric);
+        expect(chart, isNotNull, reason: metric);
+        expect(chart!.type, ChartType.timeSeries, reason: metric);
+        expect(chart.aggregation, AnalyticsAggregation.sum, reason: metric);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Converts the profile analytics screen to the standardized Thesa-gated metrics pipeline (ui_core `^0.5.0`, currently unpublished — local builds use a gitignored `pubspec_overrides.yaml` path override; the tracked `pubspec.lock` is intentionally left untouched until 0.5.0 publishes).
- Entity counts from the profile API are kept; `profileAnalyticsSpec` adds the activity instruments:
  - `devices/caching/cache_hits` vs `devices/caching/cache_misses` — KPI cards plus a client-computed Cache Hit Ratio
  - `service_geolocation/ingestion/accepted` vs `service_geolocation/ingestion/rejected` — combined time-series chart
- The mock 'Recent Events' placeholder list is removed entirely; no fabricated data remains.
- Friendly UI states for gate 400/403/5xx responses; tenant scoping stays server-side (no tenant filters sent).

## Tests
- Mocked-transport contract tests pinning the exact POST bodies per query.
- Widget tests for data, hit-ratio computation/omission, 400/403/503 friendly errors, and empty states.
- Screen-level regression test asserting the placeholder events are gone.
- `flutter analyze --no-fatal-infos` clean, `dart format` clean, `flutter test` green (12 tests).