### PR TITLE
fix(settings): allow empty Setting.name so ListRequest can match all

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	buf.build/gen/go/antinvestor/notification/protocolbuffers/go v1.36.11-20260511135618-9b1ea0d95bd7.1
 	buf.build/gen/go/antinvestor/profile/connectrpc/go v1.20.0-20260511135702-c54f3e4a0a91.1
 	buf.build/gen/go/antinvestor/profile/protocolbuffers/go v1.36.11-20260511135702-c54f3e4a0a91.1
-	buf.build/gen/go/antinvestor/settingz/connectrpc/go v1.20.0-20260511135702-ef4900faa6be.1
-	buf.build/gen/go/antinvestor/settingz/protocolbuffers/go v1.36.11-20260511135702-ef4900faa6be.1
+	buf.build/gen/go/antinvestor/settingz/connectrpc/go v1.20.0-20260612020938-aeb5e31e6f4a.1
+	buf.build/gen/go/antinvestor/settingz/protocolbuffers/go v1.36.11-20260612020938-aeb5e31e6f4a.1
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1
 	connectrpc.com/connect v1.20.0
 	firebase.google.com/go/v4 v4.20.0

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,12 @@ buf.build/gen/go/antinvestor/profile/protocolbuffers/go v1.36.11-20260511135702-
 buf.build/gen/go/antinvestor/profile/protocolbuffers/go v1.36.11-20260511135702-c54f3e4a0a91.1/go.mod h1:Fst3GhuP6DjMU6ZkauzaPFx8m/rLvwo2fUpuhk5tb5w=
 buf.build/gen/go/antinvestor/settingz/connectrpc/go v1.20.0-20260511135702-ef4900faa6be.1 h1:uECtlslfQ8sLeuFe8GNGopR0ukNh3AIr5/n2lnYhNPs=
 buf.build/gen/go/antinvestor/settingz/connectrpc/go v1.20.0-20260511135702-ef4900faa6be.1/go.mod h1:UjbIeNmPvXv2YPqiQJUUWg+ySTI9SBl+RXjHSuYY5mM=
+buf.build/gen/go/antinvestor/settingz/connectrpc/go v1.20.0-20260612020938-aeb5e31e6f4a.1 h1:GIM3yHeCEI/EieKBW8vbiavZBJum/nEqzjS59e3Png0=
+buf.build/gen/go/antinvestor/settingz/connectrpc/go v1.20.0-20260612020938-aeb5e31e6f4a.1/go.mod h1:yh3o+ge0PpPp0Br2Tijg5h3PGRawOOOg3QxKnmQAANw=
 buf.build/gen/go/antinvestor/settingz/protocolbuffers/go v1.36.11-20260511135702-ef4900faa6be.1 h1:oPbdLghteqVLacW6VCbiLf41xzrpmlCBTxxmjYk/3zk=
 buf.build/gen/go/antinvestor/settingz/protocolbuffers/go v1.36.11-20260511135702-ef4900faa6be.1/go.mod h1:zkRCi1DLStznOaqUuvL4fvhVkP6oZSipSRrhHWnihbE=
+buf.build/gen/go/antinvestor/settingz/protocolbuffers/go v1.36.11-20260612020938-aeb5e31e6f4a.1 h1:jOX0+ekMV4f8nvE7LO7FtiCL0hJXaCBFCYvXfSao1U8=
+buf.build/gen/go/antinvestor/settingz/protocolbuffers/go v1.36.11-20260612020938-aeb5e31e6f4a.1/go.mod h1:ZWe+6mN8CC4x6AJBEpYfVGnLuHsKmKzt1o4I9ZOVyOg=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1 h1:s6hzCXtND/ICdGPTMGk7C+/BFlr2Jg5GyH0NKf4XGXg=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
 buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.11-20230414000709-087bc8072ce4.1 h1:t8f+WWZ5WNrZaP5zrpWD8f1tKU7eelJMbIAT9FRX558=

--- a/proto/settings/settings/v1/settings.proto
+++ b/proto/settings/settings/v1/settings.proto
@@ -68,7 +68,10 @@ option (gnostic.openapi.v3.document) = {
 // Setting represents a hierarchical key for configuration lookup.
 // Supports multi-level scoping for flexible configuration management.
 message Setting {
-  string name = 1 [(buf.validate.field).string.min_len = 2]; // Setting name (e.g., "theme", "max_upload_size")
+  string name = 1 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).string.min_len = 2
+  ]; // Setting name (e.g., "theme", "max_upload_size"); empty in ListRequest keys to match all
   string object = 2 [
     (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).string.min_len = 2


### PR DESCRIPTION
## Summary
`ListRequest` documents *"empty fields match all"* and `SearchRef` treats name as a substring filter (`iLike '%name%'`, empty = list everything) — but `Setting.name` was the only key field without `IGNORE_IF_ZERO_VALUE`, so protovalidate rejected every list-all call with `key.name: must be at least 2 characters`. The thesa admin console's **All Settings** page could never list a partition's settings.

Empty name now passes validation; non-empty names still require `min_len 2`.

## Rollout
After merge: `buf push` the settingz module, bump the generated `buf.build/gen/go/antinvestor/settingz` modules in go.mod, release the settings app.