### PR TITLE
fix(profile): read profile/contact back from primary after create

### DIFF
--- a/apps/default/service/business/contacts.go
+++ b/apps/default/service/business/contacts.go
@@ -156,7 +156,10 @@ func (cb *contactBusiness) UpdateContact(
 	profileID string,
 	extra data.JSONMap,
 ) (*models.Contact, error) {
-	contact, err := cb.contactRepository.GetByID(ctx, contactID)
+	// Read from the primary: UpdateContact is a read-modify-write, and during
+	// CreateProfile the contact was created moments earlier — a replica read
+	// can miss it (read-your-writes).
+	contact, err := cb.contactRepository.GetByIDFromPrimary(ctx, contactID)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/default/service/business/profiles.go
+++ b/apps/default/service/business/profiles.go
@@ -436,7 +436,14 @@ func (pb *profileBusiness) CreateProfile(
 		return nil, err
 	}
 
-	return pb.GetByID(ctx, contact.ProfileID)
+	// Read the just-created profile back from the primary — the replica that
+	// GetByID uses lags the write (or cannot see the still-uncommitted row),
+	// which surfaced as "record not found" on every profile creation.
+	profile, getErr := pb.profileRepo.GetByIDFromPrimary(ctx, contact.ProfileID)
+	if getErr != nil {
+		return nil, data.ErrorConvertToAPI(getErr)
+	}
+	return pb.ToAPI(ctx, profile)
 }
 
 // func (pb *profileBusiness) UpdateProperties(db *gorm.DB, params data.JSONMap) error {

--- a/apps/default/service/repository/contacts.go
+++ b/apps/default/service/repository/contacts.go
@@ -51,6 +51,17 @@ func (cr *contactRepository) GetByProfileID(ctx context.Context, profileID strin
 	return contactList, err
 }
 
+// GetByIDFromPrimary reads from the primary connection so a contact created
+// moments earlier (e.g. linking it to a new profile during CreateProfile) is
+// visible. The replica-backed BaseRepository.GetByID can miss it under
+// replica lag / before the request transaction commits.
+func (cr *contactRepository) GetByIDFromPrimary(ctx context.Context, id string) (*models.Contact, error) {
+	unscopedCtx := security.SkipTenancyChecksOnClaims(ctx)
+	contact := &models.Contact{}
+	err := cr.Pool().DB(unscopedCtx, false).First(contact, "id = ?", id).Error
+	return contact, err
+}
+
 func (cr *contactRepository) GetByLookupToken(
 	ctx context.Context,
 	lookupTokenList ...[]byte,

--- a/apps/default/service/repository/interfaces.go
+++ b/apps/default/service/repository/interfaces.go
@@ -23,6 +23,11 @@ type ProfileRepository interface {
 		ctx context.Context,
 		profileType profilev1.ProfileType,
 	) (*models.ProfileType, error)
+
+	// GetByIDFromPrimary reads from the primary (read-write) connection so a
+	// just-created profile is visible (read-your-writes). The replica-backed
+	// GetByID can miss a row written moments earlier under replica lag.
+	GetByIDFromPrimary(ctx context.Context, id string) (*models.Profile, error)
 }
 
 type ContactRepository interface {
@@ -30,6 +35,10 @@ type ContactRepository interface {
 	GetByProfileID(ctx context.Context, profileID string) ([]*models.Contact, error)
 	GetByLookupToken(ctx context.Context, lookUpToken ...[]byte) ([]*models.Contact, error)
 	DelinkFromProfile(ctx context.Context, id, profileID string) (*models.Contact, error)
+
+	// GetByIDFromPrimary reads from the primary connection for
+	// read-your-writes (e.g. linking a just-created contact to a profile).
+	GetByIDFromPrimary(ctx context.Context, id string) (*models.Contact, error)
 }
 
 type VerificationRepository interface {

--- a/apps/default/service/repository/profiles.go
+++ b/apps/default/service/repository/profiles.go
@@ -57,6 +57,18 @@ func (pr *profileRepository) GetByID(ctx context.Context, id string) (*models.Pr
 	return profile, err
 }
 
+// GetByIDFromPrimary mirrors GetByID but reads from the primary (read-write)
+// connection. CreateProfile reads the profile back immediately after writing
+// it; the replica GetByID uses lags behind that write (or never sees the
+// still-uncommitted row inside the request), returning "record not found".
+// Reading the primary guarantees read-your-writes.
+func (pr *profileRepository) GetByIDFromPrimary(ctx context.Context, id string) (*models.Profile, error) {
+	unscopedCtx := security.SkipTenancyChecksOnClaims(ctx)
+	profile := &models.Profile{}
+	err := pr.Pool().DB(unscopedCtx, false).Preload(clause.Associations).First(profile, "id = ?", id).Error
+	return profile, err
+}
+
 func (pr *profileRepository) Save(ctx context.Context, tenant *models.Profile) error {
 	return pr.Pool().DB(ctx, false).Save(tenant).Error
 }


### PR DESCRIPTION
CreateProfile (and UpdateContact's read-modify-write) read the
just-written row back through GetByID, which uses the read-only replica
connection (DB(ctx, true)). The replica lags the primary write — and
inside the request the row may still be uncommitted — so the read-back
returned "record not found", failing every profile creation from the
admin console with a generic error.

Add GetByIDFromPrimary (DB(ctx, false)) to the profile and contact
repositories and use it for the post-write read-backs in CreateProfile
and UpdateContact, guaranteeing read-your-writes. Other reads keep using
the replica.
