### PR TITLE
fix(profile): build CreateProfile response in-memory, no read-back

### DIFF
--- a/apps/default/service/business/contacts.go
+++ b/apps/default/service/business/contacts.go
@@ -38,6 +38,7 @@ type ContactBusiness interface {
 		profileID string,
 		extra data.JSONMap,
 	) (*models.Contact, error)
+	LinkToProfile(ctx context.Context, contact *models.Contact, profileID string) (*models.Contact, error)
 	RemoveContact(ctx context.Context, contactID, profileID string) (*models.Contact, error)
 	VerifyContact(
 		ctx context.Context,
@@ -171,6 +172,22 @@ func (cb *contactBusiness) UpdateContact(
 
 	_, err = cb.contactRepository.Update(ctx, contact, "profile_id", "properties")
 	if err != nil {
+		return nil, err
+	}
+	return contact, nil
+}
+
+// LinkToProfile sets profile_id on an already-loaded contact and persists
+// just that column. Unlike UpdateContact it does NOT re-read the contact
+// first — used by CreateProfile, where the contact was created earlier in
+// the same request transaction and a read-back would not yet see it.
+func (cb *contactBusiness) LinkToProfile(
+	ctx context.Context,
+	contact *models.Contact,
+	profileID string,
+) (*models.Contact, error) {
+	contact.ProfileID = profileID
+	if _, err := cb.contactRepository.Update(ctx, contact, "profile_id"); err != nil {
 		return nil, err
 	}
 	return contact, nil

--- a/apps/default/service/business/profiles.go
+++ b/apps/default/service/business/profiles.go
@@ -431,19 +431,40 @@ func (pb *profileBusiness) CreateProfile(
 		}
 	}
 
-	contact, err = pb.contactBusiness.UpdateContact(ctx, contact.GetID(), p.GetID(), nil)
+	// Link the contact to the new profile in-memory and persist just the FK,
+	// then build the response from the objects we already hold. Both the
+	// profile and contact were written earlier in THIS request's
+	// transaction; any read-back (replica or primary) runs on a connection
+	// that cannot see those uncommitted rows, so it returned "record not
+	// found" and rolled the whole creation back. Avoiding read-backs lets
+	// the transaction commit.
+	contact, err = pb.contactBusiness.LinkToProfile(ctx, contact, p.GetID())
 	if err != nil {
 		return nil, err
 	}
 
-	// Read the just-created profile back from the primary — the replica that
-	// GetByID uses lags the write (or cannot see the still-uncommitted row),
-	// which surfaced as "record not found" on every profile creation.
-	profile, getErr := pb.profileRepo.GetByIDFromPrimary(ctx, contact.ProfileID)
-	if getErr != nil {
-		return nil, data.ErrorConvertToAPI(getErr)
+	return pb.profileFromCreated(&p, contact)
+}
+
+// profileFromCreated builds a ProfileObject from the just-created profile and
+// its contact without any further reads (see CreateProfile for why).
+func (pb *profileBusiness) profileFromCreated(
+	p *models.Profile,
+	contact *models.Contact,
+) (*profilev1.ProfileObject, error) {
+	obj := &profilev1.ProfileObject{
+		Id:         p.ID,
+		Type:       models.ProfileTypeIDToEnum(p.ProfileType.UID),
+		Properties: p.Properties.ToProtoStruct(),
 	}
-	return pb.ToAPI(ctx, profile)
+	if contact != nil {
+		contactObj, err := contact.ToAPI(pb.dek, true)
+		if err != nil {
+			return nil, err
+		}
+		obj.Contacts = []*profilev1.ContactObject{contactObj}
+	}
+	return obj, nil
 }
 
 // func (pb *profileBusiness) UpdateProperties(db *gorm.DB, params data.JSONMap) error {

--- a/apps/default/service/repository/interfaces.go
+++ b/apps/default/service/repository/interfaces.go
@@ -23,11 +23,6 @@ type ProfileRepository interface {
 		ctx context.Context,
 		profileType profilev1.ProfileType,
 	) (*models.ProfileType, error)
-
-	// GetByIDFromPrimary reads from the primary (read-write) connection so a
-	// just-created profile is visible (read-your-writes). The replica-backed
-	// GetByID can miss a row written moments earlier under replica lag.
-	GetByIDFromPrimary(ctx context.Context, id string) (*models.Profile, error)
 }
 
 type ContactRepository interface {

--- a/apps/default/service/repository/profiles.go
+++ b/apps/default/service/repository/profiles.go
@@ -57,18 +57,6 @@ func (pr *profileRepository) GetByID(ctx context.Context, id string) (*models.Pr
 	return profile, err
 }
 
-// GetByIDFromPrimary mirrors GetByID but reads from the primary (read-write)
-// connection. CreateProfile reads the profile back immediately after writing
-// it; the replica GetByID uses lags behind that write (or never sees the
-// still-uncommitted row inside the request), returning "record not found".
-// Reading the primary guarantees read-your-writes.
-func (pr *profileRepository) GetByIDFromPrimary(ctx context.Context, id string) (*models.Profile, error) {
-	unscopedCtx := security.SkipTenancyChecksOnClaims(ctx)
-	profile := &models.Profile{}
-	err := pr.Pool().DB(unscopedCtx, false).Preload(clause.Associations).First(profile, "id = ?", id).Error
-	return profile, err
-}
-
 func (pr *profileRepository) Save(ctx context.Context, tenant *models.Profile) error {
 	return pr.Pool().DB(ctx, false).Save(tenant).Error
 }


### PR DESCRIPTION
The previous fix routed the post-create read-backs to the primary, but
the create handler runs inside a request transaction and the read-backs
execute on a connection that cannot see those still-uncommitted rows —
so GetByID still returned "record not found" and the transaction rolled
back, failing every profile creation.

Eliminate the read-backs entirely: link the just-created contact to the
new profile in-memory (LinkToProfile, no re-read) and build the
ProfileObject from the profile + contact already in hand
(profileFromCreated). The handler now returns success and the
transaction commits. Removes the now-unused profile GetByIDFromPrimary;
keeps the contact one for UpdateContact's read-modify-write.
