### PR TITLE
fix(geolocation): SearchAreas/SearchRoutes list all when no filter given

### DIFF
--- a/apps/geolocation/service/business/areas.go
+++ b/apps/geolocation/service/business/areas.go
@@ -234,10 +234,11 @@ func (b *areaBusiness) SearchAreas(
 	switch {
 	case ownerID != "":
 		areas, err = b.areaRepo.SearchByOwner(ctx, ownerID, limit)
-	case query != "":
-		areas, err = b.areaRepo.SearchByQuery(ctx, query, limit)
 	default:
-		return nil, errors.New("either query or owner_id is required for area search")
+		// An empty query lists all areas (admin console list view); a
+		// non-empty query filters by name/description. SearchByQuery with an
+		// empty term matches every row up to the limit.
+		areas, err = b.areaRepo.SearchByQuery(ctx, query, limit)
 	}
 
 	if err != nil {

--- a/apps/geolocation/service/business/business_integration_test.go
+++ b/apps/geolocation/service/business/business_integration_test.go
@@ -592,14 +592,6 @@ func (s *BusinessSuite) TestRouteDeviationCatchupRetentionAndValidation() {
 				name: "nil ingest request",
 				run:  func() error { _, e := stack.IngestionBiz.IngestBatch(ctx, nil); return e },
 			},
-			{
-				name: "invalid area search",
-				run:  func() error { _, e := stack.AreaBiz.SearchAreas(ctx, "", "", 0); return e },
-			},
-			{
-				name: "invalid route search",
-				run:  func() error { _, e := stack.RouteBiz.SearchRoutes(ctx, "", 0); return e },
-			},
 			{name: "invalid nearby subject request", run: func() error {
 				_, e := stack.ProximityBiz.GetNearbySubjects(ctx, &models.GetNearbySubjectsRequest{})
 				return e

--- a/apps/geolocation/service/business/route.go
+++ b/apps/geolocation/service/business/route.go
@@ -238,10 +238,9 @@ func (b *routeBusiness) SearchRoutes(
 	if limit <= 0 {
 		limit = defaultSearchLimit
 	}
-	if ownerID == "" {
-		return nil, errors.New("owner_id is required for route search")
-	}
 
+	// An empty owner_id lists all routes (admin console list view);
+	// a non-empty owner_id filters to that owner.
 	routes, err := b.routeRepo.SearchByOwner(ctx, ownerID, limit)
 	if err != nil {
 		return nil, fmt.Errorf("search routes: %w", err)

--- a/apps/geolocation/service/handlers/geolocation_handler_test.go
+++ b/apps/geolocation/service/handlers/geolocation_handler_test.go
@@ -160,6 +160,14 @@ func (s *HandlerSuite) TestGeolocationServerFlow() {
 		require.NoError(t, err)
 		require.Len(t, searchedAreas.Msg.GetData(), 1)
 
+		// Empty filter lists all areas (admin console list view).
+		allAreas, err := server.SearchAreas(
+			ctx,
+			connect.NewRequest(&geolocationv1.SearchAreasRequest{Limit: 10}),
+		)
+		require.NoError(t, err)
+		require.Len(t, allAreas.Msg.GetData(), 1)
+
 		routeResp, err := server.CreateRoute(ctx, connect.NewRequest(&geolocationv1.CreateRouteRequest{
 			Data: &geolocationv1.RouteObject{
 				OwnerId: "owner-1", Name: "Handler Route",
@@ -186,6 +194,14 @@ func (s *HandlerSuite) TestGeolocationServerFlow() {
 		)
 		require.NoError(t, err)
 		require.Len(t, searchedRoutes.Msg.GetData(), 1)
+
+		// Empty filter lists all routes (admin console list view).
+		allRoutes, err := server.SearchRoutes(
+			ctx,
+			connect.NewRequest(&geolocationv1.SearchRoutesRequest{Limit: 10}),
+		)
+		require.NoError(t, err)
+		require.Len(t, allRoutes.Msg.GetData(), 1)
 
 		assignResp, err := server.AssignRoute(
 			ctx,
@@ -359,14 +375,6 @@ func (s *HandlerSuite) TestGeolocationServerErrorPaths() {
 				code: connect.CodeNotFound,
 			},
 			{
-				name: "search areas invalid",
-				run: func() error {
-					_, err := server.SearchAreas(ctx, connect.NewRequest(&geolocationv1.SearchAreasRequest{}))
-					return err
-				},
-				code: connect.CodeInvalidArgument,
-			},
-			{
 				name: "create invalid route",
 				run: func() error {
 					_, err := server.CreateRoute(ctx, connect.NewRequest(&geolocationv1.CreateRouteRequest{
@@ -409,14 +417,6 @@ func (s *HandlerSuite) TestGeolocationServerErrorPaths() {
 					return err
 				},
 				code: connect.CodeNotFound,
-			},
-			{
-				name: "search routes invalid",
-				run: func() error {
-					_, err := server.SearchRoutes(ctx, connect.NewRequest(&geolocationv1.SearchRoutesRequest{}))
-					return err
-				},
-				code: connect.CodeInvalidArgument,
 			},
 			{
 				name: "assign route missing ids",

--- a/apps/geolocation/service/repository/routes.go
+++ b/apps/geolocation/service/repository/routes.go
@@ -160,7 +160,11 @@ func (r *routeRepository) SearchByOwner(
 ) ([]*models.Route, error) {
 	var routes []*models.Route
 	db := r.Pool().DB(ctx, true)
-	query := db.Where("owner_id = ? AND deleted_at IS NULL", ownerID).Order("created_at DESC")
+	query := db.Where("deleted_at IS NULL").Order("created_at DESC")
+	// An empty owner_id lists all routes (admin console list view).
+	if ownerID != "" {
+		query = query.Where("owner_id = ?", ownerID)
+	}
 	if limit > 0 {
 		query = query.Limit(limit)
 	}


### PR DESCRIPTION
## Summary
The admin console's Geolocation list screens (Areas, Routes) call `SearchAreas`/`SearchRoutes` with no query/owner to list everything. The handlers required a filter (`either query or owner_id is required` / `owner_id is required for route search`) and returned `InvalidArgument`, so the screens rendered a generic 'An unexpected error occurred.'

## Root cause
Found while walking the Thesa console end-to-end: after fixing the OAuth audience (so the geo token is now accepted — service-auth #724, thesa-ui #27), the screens still errored. The geo service was rejecting the empty 'list all' search at the business layer.

## Changes
- `SearchAreas`: empty query lists all areas (`SearchByQuery` with an empty term matches all up to the limit); non-empty query still filters by name/description.
- `SearchRoutes`: empty owner_id lists all routes; the repo only applies the `owner_id` predicate when set.
- Tests: drop the now-valid 'empty search errors' cases; add list-all assertions. Handler + business suites pass.

## Verification
`go test ./apps/geolocation/service/{handlers,business}/` pass (testcontainers).